### PR TITLE
[FEATURE] 회원가입 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 
     // Actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/tteokguk/tteokguk/global/exception/error/ErrorResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/exception/error/ErrorResponse.java
@@ -7,6 +7,9 @@ import java.util.Optional;
 
 import org.springframework.validation.FieldError;
 
+import lombok.Getter;
+
+@Getter
 public class ErrorResponse {
 
 	private final String timeStamp;

--- a/src/main/java/com/tteokguk/tteokguk/global/security/SecurityConfig.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/security/SecurityConfig.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -17,5 +19,10 @@ public class SecurityConfig {
 			.csrf(AbstractHttpConfigurer::disable)
 			.formLogin(AbstractHttpConfigurer::disable)
 			.build();
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return PasswordEncoderFactories.createDelegatingPasswordEncoder();
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/application/AuthService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/AuthService.java
@@ -30,7 +30,7 @@ public class AuthService {
 			throw new BusinessException(AuthError.DUPLICATE_NICKNAME);
 
 		SimpleMember saved = simpleMemberRepository.save(
-			SimpleMember.join(request.email(), encoder.encode(request.password()), request.nickname())
+			SimpleMember.of(request.email(), encoder.encode(request.password()), request.nickname())
 		);
 		return saved.getId();
 	}

--- a/src/main/java/com/tteokguk/tteokguk/member/application/AuthService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/AuthService.java
@@ -1,0 +1,27 @@
+package com.tteokguk.tteokguk.member.application;
+
+import org.springframework.stereotype.Service;
+
+import com.tteokguk.tteokguk.member.application.dto.AppJoinRequest;
+import com.tteokguk.tteokguk.member.domain.SimpleMember;
+import com.tteokguk.tteokguk.member.infra.persistence.MemberRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final MemberRepository memberRepository;
+
+	public Long join(AppJoinRequest request) {
+		SimpleMember saved = memberRepository.save(
+			SimpleMember.join(request.email(), request.password(), request.nickname())
+		);
+		return saved.getId();
+	}
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/application/AuthService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/AuthService.java
@@ -1,5 +1,6 @@
 package com.tteokguk.tteokguk.member.application;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.tteokguk.tteokguk.member.application.dto.AppJoinRequest;
@@ -17,10 +18,11 @@ import lombok.extern.slf4j.Slf4j;
 public class AuthService {
 
 	private final MemberRepository memberRepository;
+	private final PasswordEncoder encoder;
 
 	public Long join(AppJoinRequest request) {
 		SimpleMember saved = memberRepository.save(
-			SimpleMember.join(request.email(), request.password(), request.nickname())
+			SimpleMember.join(request.email(), encoder.encode(request.password()), request.nickname())
 		);
 		return saved.getId();
 	}

--- a/src/main/java/com/tteokguk/tteokguk/member/application/AuthService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/AuthService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 
 import com.tteokguk.tteokguk.global.exception.BusinessException;
 import com.tteokguk.tteokguk.member.application.dto.AppJoinRequest;
+import com.tteokguk.tteokguk.member.application.dto.AppJoinResponse;
 import com.tteokguk.tteokguk.member.domain.SimpleMember;
 import com.tteokguk.tteokguk.member.exception.AuthError;
 import com.tteokguk.tteokguk.member.infra.persistence.SimpleMemberRepository;
@@ -22,17 +23,17 @@ public class AuthService {
 	private final SimpleMemberRepository simpleMemberRepository;
 	private final PasswordEncoder encoder;
 
-	public Long join(AppJoinRequest request) {
+	public AppJoinResponse join(AppJoinRequest request) {
 		if (existsByEmail(request.email()))
 			throw new BusinessException(AuthError.DUPLICATE_EMAIL);
 
 		if (existsByNickname(request.nickname()))
 			throw new BusinessException(AuthError.DUPLICATE_NICKNAME);
 
-		SimpleMember saved = simpleMemberRepository.save(
+		SimpleMember entity = simpleMemberRepository.save(
 			SimpleMember.of(request.email(), encoder.encode(request.password()), request.nickname())
 		);
-		return saved.getId();
+		return AppJoinResponse.of(entity);
 	}
 
 	public boolean existsByEmail(String email) {

--- a/src/main/java/com/tteokguk/tteokguk/member/application/AuthService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/AuthService.java
@@ -3,9 +3,11 @@ package com.tteokguk.tteokguk.member.application;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import com.tteokguk.tteokguk.global.exception.BusinessException;
 import com.tteokguk.tteokguk.member.application.dto.AppJoinRequest;
 import com.tteokguk.tteokguk.member.domain.SimpleMember;
-import com.tteokguk.tteokguk.member.infra.persistence.MemberRepository;
+import com.tteokguk.tteokguk.member.exception.AuthError;
+import com.tteokguk.tteokguk.member.infra.persistence.SimpleMemberRepository;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -17,13 +19,20 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class AuthService {
 
-	private final MemberRepository memberRepository;
+	private final SimpleMemberRepository simpleMemberRepository;
 	private final PasswordEncoder encoder;
 
 	public Long join(AppJoinRequest request) {
-		SimpleMember saved = memberRepository.save(
+		if (existsByEmail(request.email()))
+			throw new BusinessException(AuthError.DUPLICATE_EMAIL);
+
+		SimpleMember saved = simpleMemberRepository.save(
 			SimpleMember.join(request.email(), encoder.encode(request.password()), request.nickname())
 		);
 		return saved.getId();
+	}
+
+	public boolean existsByEmail(String email) {
+		return simpleMemberRepository.existsByEmail(email);
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/application/AuthService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/AuthService.java
@@ -26,6 +26,9 @@ public class AuthService {
 		if (existsByEmail(request.email()))
 			throw new BusinessException(AuthError.DUPLICATE_EMAIL);
 
+		if (existsByNickname(request.nickname()))
+			throw new BusinessException(AuthError.DUPLICATE_NICKNAME);
+
 		SimpleMember saved = simpleMemberRepository.save(
 			SimpleMember.join(request.email(), encoder.encode(request.password()), request.nickname())
 		);
@@ -34,5 +37,9 @@ public class AuthService {
 
 	public boolean existsByEmail(String email) {
 		return simpleMemberRepository.existsByEmail(email);
+	}
+
+	public boolean existsByNickname(String nickname) {
+		return simpleMemberRepository.existsByNickname(nickname);
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/application/dto/AppJoinRequest.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/dto/AppJoinRequest.java
@@ -1,0 +1,8 @@
+package com.tteokguk.tteokguk.member.application.dto;
+
+public record AppJoinRequest(
+	String email,
+	String password,
+	String nickname
+) {
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/application/dto/AppJoinResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/dto/AppJoinResponse.java
@@ -1,0 +1,17 @@
+package com.tteokguk.tteokguk.member.application.dto;
+
+import com.tteokguk.tteokguk.member.domain.Member;
+
+public record AppJoinResponse(
+	Long id,
+	String nickname,
+	String primaryIngredient
+) {
+	public static AppJoinResponse of(Member entity) {
+		return new AppJoinResponse(
+			entity.getId(),
+			entity.getNickname(),
+			entity.getPrimaryIngredient().name()
+		);
+	}
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/Inventory.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/Inventory.java
@@ -5,6 +5,7 @@ import static jakarta.persistence.FetchType.*;
 import static jakarta.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.tteokguk.tteokguk.tteokguk.constants.Ingredient;
 
 import jakarta.persistence.Column;
@@ -36,7 +37,14 @@ public class Inventory {
 	@Column(name = "stock_quantity")
 	private int stockQuantity;
 
+	@JsonIgnore
 	@JoinColumn(name = "member_id")
 	@ManyToOne(fetch = LAZY)
 	private Member member;
+
+	public Inventory(Ingredient ingredient, int stockQuantity, Member member) {
+		this.ingredient = ingredient;
+		this.stockQuantity = stockQuantity;
+		this.member = member;
+	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/Member.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/Member.java
@@ -18,6 +18,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
@@ -27,6 +28,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "t_member")
 @NoArgsConstructor(access = PROTECTED)
+@Inheritance
 public class Member extends BaseEntity {
 
 	@Id
@@ -47,4 +49,10 @@ public class Member extends BaseEntity {
 		orphanRemoval = true)
 	@OnDelete(action = CASCADE)
 	private List<Inventory> inventory;
+
+	protected Member(Ingredient primaryIngredient, String nickname, List<Inventory> inventory) {
+		this.primaryIngredient = primaryIngredient;
+		this.nickname = nickname;
+		this.inventory = inventory;
+	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/Member.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/Member.java
@@ -9,6 +9,7 @@ import static org.hibernate.annotations.OnDeleteAction.*;
 import java.util.List;
 
 import org.hibernate.annotations.OnDelete;
+import org.springframework.util.ObjectUtils;
 
 import com.tteokguk.tteokguk.global.auditing.BaseEntity;
 import com.tteokguk.tteokguk.tteokguk.constants.Ingredient;
@@ -54,5 +55,22 @@ public class Member extends BaseEntity {
 		this.primaryIngredient = primaryIngredient;
 		this.nickname = nickname;
 		this.inventory = inventory;
+	}
+
+	public void store(Ingredient ingredient, int quantity) {
+		List<Inventory> filteredInventory = getInventory().stream()
+			.filter(i -> ObjectUtils.nullSafeEquals(i.getIngredient(), ingredient))
+			.toList();
+
+		if (filteredInventory.isEmpty()) {
+			getInventory().add(new Inventory(ingredient, quantity, this));
+		} else {
+			// TODO: inventory에 데이터가 있는 경우 해당 데이터에서 stockQuantity를 늘려줘야 한다. (Atomic)
+		}
+	}
+
+	protected void initInventory(Ingredient primaryIngredient) {
+		final int INF = 1_000_000_000;
+		store(primaryIngredient, INF);
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/SimpleMember.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/SimpleMember.java
@@ -29,16 +29,15 @@ public class SimpleMember extends Member {
 		String email,
 		String password,
 		String nickname,
-		Ingredient ingredient,
+		Ingredient primaryIngredient,
 		List<Inventory> inventory
 	) {
-		super(ingredient, nickname, inventory);
+		super(primaryIngredient, nickname, inventory);
 		this.email = email;
 		this.password = password;
 	}
 
-	// TODO: 전용 재료를 회원 가입 때 정하는 로직을 구현해야 한다.
-	public static SimpleMember join(String email, String password, String nickname) {
-		return new SimpleMember(email, password, nickname, Ingredient.BEEF, new ArrayList<>());
+	public static SimpleMember of(String email, String password, String nickname) {
+		return new SimpleMember(email, password, nickname, Ingredient.random(), new ArrayList<>());
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/SimpleMember.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/SimpleMember.java
@@ -38,6 +38,7 @@ public class SimpleMember extends Member {
 	}
 
 	// TODO: 전용 재료를 회원 가입 때 정하는 로직을 구현해야 한다.
+	// TODO: Password Encoder를 통해 비밀번호를 암호화해야 한다.
 	public static SimpleMember join(String email, String password, String nickname) {
 		return new SimpleMember(email, password, nickname, Ingredient.BEEF, new ArrayList<>());
 	}

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/SimpleMember.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/SimpleMember.java
@@ -5,6 +5,8 @@ import static lombok.AccessLevel.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.util.ObjectUtils;
+
 import com.tteokguk.tteokguk.tteokguk.constants.Ingredient;
 
 import jakarta.persistence.Column;
@@ -38,6 +40,10 @@ public class SimpleMember extends Member {
 	}
 
 	public static SimpleMember of(String email, String password, String nickname) {
-		return new SimpleMember(email, password, nickname, Ingredient.random(), new ArrayList<>());
+		Ingredient primaryIngredient = Ingredient.random();
+
+		SimpleMember entity = new SimpleMember(email, password, nickname, primaryIngredient, new ArrayList<>());
+		entity.initInventory(primaryIngredient);
+		return entity;
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/SimpleMember.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/SimpleMember.java
@@ -38,7 +38,6 @@ public class SimpleMember extends Member {
 	}
 
 	// TODO: 전용 재료를 회원 가입 때 정하는 로직을 구현해야 한다.
-	// TODO: Password Encoder를 통해 비밀번호를 암호화해야 한다.
 	public static SimpleMember join(String email, String password, String nickname) {
 		return new SimpleMember(email, password, nickname, Ingredient.BEEF, new ArrayList<>());
 	}

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/SimpleMember.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/SimpleMember.java
@@ -1,0 +1,44 @@
+package com.tteokguk.tteokguk.member.domain;
+
+import static lombok.AccessLevel.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.tteokguk.tteokguk.tteokguk.constants.Ingredient;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class SimpleMember extends Member {
+
+	@Column(name = "email",
+		updatable = false,
+		unique = true)
+	private String email;
+
+	@Column(name = "password")
+	private String password;
+
+	private SimpleMember(
+		String email,
+		String password,
+		String nickname,
+		Ingredient ingredient,
+		List<Inventory> inventory
+	) {
+		super(ingredient, nickname, inventory);
+		this.email = email;
+		this.password = password;
+	}
+
+	// TODO: 전용 재료를 회원 가입 때 정하는 로직을 구현해야 한다.
+	public static SimpleMember join(String email, String password, String nickname) {
+		return new SimpleMember(email, password, nickname, Ingredient.BEEF, new ArrayList<>());
+	}
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/exception/AuthError.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/exception/AuthError.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 public enum AuthError implements ErrorCode {
 
 	DUPLICATE_EMAIL("이메일이 중복되었습니다.", HttpStatus.BAD_REQUEST, "A001"),
+	DUPLICATE_NICKNAME("닉네임이 중복되었습니다.", HttpStatus.BAD_REQUEST, "A002"),
 	;
 
 	private final String message;

--- a/src/main/java/com/tteokguk/tteokguk/member/exception/AuthError.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/exception/AuthError.java
@@ -1,0 +1,20 @@
+package com.tteokguk.tteokguk.member.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.tteokguk.tteokguk.global.exception.error.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthError implements ErrorCode {
+
+	DUPLICATE_EMAIL("이메일이 중복되었습니다.", HttpStatus.BAD_REQUEST, "A001"),
+	;
+
+	private final String message;
+	private final HttpStatus status;
+	private final String code;
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/infra/persistence/MemberRepository.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/infra/persistence/MemberRepository.java
@@ -6,5 +6,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.tteokguk.tteokguk.member.domain.Member;
 
 @Transactional
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository<T extends Member> extends JpaRepository<T, Long> {
+
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/infra/persistence/MemberRepository.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/infra/persistence/MemberRepository.java
@@ -7,5 +7,5 @@ import com.tteokguk.tteokguk.member.domain.Member;
 
 @Transactional
 public interface MemberRepository<T extends Member> extends JpaRepository<T, Long> {
-
+	boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/infra/persistence/SimpleMemberRepository.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/infra/persistence/SimpleMemberRepository.java
@@ -1,0 +1,7 @@
+package com.tteokguk.tteokguk.member.infra.persistence;
+
+import com.tteokguk.tteokguk.member.domain.SimpleMember;
+
+public interface SimpleMemberRepository extends MemberRepository<SimpleMember> {
+	boolean existsByEmail(String email);
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/AuthController.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/AuthController.java
@@ -4,12 +4,15 @@ import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.tteokguk.tteokguk.member.application.AuthService;
+import com.tteokguk.tteokguk.member.presentation.dto.WebExistedResourceResponse;
 import com.tteokguk.tteokguk.member.presentation.dto.WebJoinRequest;
 import com.tteokguk.tteokguk.member.presentation.dto.WebJoinResponse;
 
@@ -28,5 +31,11 @@ public class AuthController {
 	public ResponseEntity<WebJoinResponse> join(@RequestBody @Validated WebJoinRequest request) {
 		Long savedId = memberService.join(request.convert());
 		return ResponseEntity.created(URI.create("/api/v1/members/" + savedId)).body(new WebJoinResponse(savedId));
+	}
+
+	@GetMapping("/check-email/{email}")
+	public ResponseEntity<WebExistedResourceResponse> checkEmail(@PathVariable String email) {
+		boolean isExist = memberService.existsByEmail(email);
+		return ResponseEntity.ok(new WebExistedResourceResponse(isExist));
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/AuthController.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/AuthController.java
@@ -1,0 +1,30 @@
+package com.tteokguk.tteokguk.member.presentation;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.tteokguk.tteokguk.member.application.AuthService;
+import com.tteokguk.tteokguk.member.presentation.dto.WebJoinRequest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final AuthService memberService;
+
+	@PostMapping("/join")
+	public ResponseEntity<Void> join(@RequestBody WebJoinRequest request) {
+		Long savedId = memberService.join(request.convert());
+		return ResponseEntity.created(URI.create("/api/v1/members/" + savedId)).build();
+	}
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/AuthController.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/AuthController.java
@@ -38,4 +38,10 @@ public class AuthController {
 		boolean isExist = memberService.existsByEmail(email);
 		return ResponseEntity.ok(new WebExistedResourceResponse(isExist));
 	}
+
+	@GetMapping("/check-nickname/{nickname}")
+	public ResponseEntity<WebExistedResourceResponse> checkNickname(@PathVariable String nickname) {
+		boolean isExist = memberService.existsByNickname(nickname);
+		return ResponseEntity.ok(new WebExistedResourceResponse(isExist));
+	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/AuthController.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/AuthController.java
@@ -3,6 +3,7 @@ package com.tteokguk.tteokguk.member.presentation;
 import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.tteokguk.tteokguk.member.application.AuthService;
 import com.tteokguk.tteokguk.member.presentation.dto.WebJoinRequest;
+import com.tteokguk.tteokguk.member.presentation.dto.WebJoinResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,8 +25,8 @@ public class AuthController {
 	private final AuthService memberService;
 
 	@PostMapping("/join")
-	public ResponseEntity<Void> join(@RequestBody WebJoinRequest request) {
+	public ResponseEntity<WebJoinResponse> join(@RequestBody @Validated WebJoinRequest request) {
 		Long savedId = memberService.join(request.convert());
-		return ResponseEntity.created(URI.create("/api/v1/members/" + savedId)).build();
+		return ResponseEntity.created(URI.create("/api/v1/members/" + savedId)).body(new WebJoinResponse(savedId));
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/AuthController.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/AuthController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.tteokguk.tteokguk.member.application.AuthService;
+import com.tteokguk.tteokguk.member.application.dto.AppJoinResponse;
 import com.tteokguk.tteokguk.member.presentation.dto.WebExistedResourceResponse;
 import com.tteokguk.tteokguk.member.presentation.dto.WebJoinRequest;
 import com.tteokguk.tteokguk.member.presentation.dto.WebJoinResponse;
@@ -29,8 +30,8 @@ public class AuthController {
 
 	@PostMapping("/join")
 	public ResponseEntity<WebJoinResponse> join(@RequestBody @Validated WebJoinRequest request) {
-		Long savedId = memberService.join(request.convert());
-		return ResponseEntity.created(URI.create("/api/v1/members/" + savedId)).body(new WebJoinResponse(savedId));
+		AppJoinResponse appResponse = memberService.join(request.convert());
+		return ResponseEntity.created(URI.create("/api/v1/members/" + appResponse.id())).body(WebJoinResponse.of(appResponse));
 	}
 
 	@GetMapping("/check-email/{email}")

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebExistedResourceResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebExistedResourceResponse.java
@@ -1,0 +1,6 @@
+package com.tteokguk.tteokguk.member.presentation.dto;
+
+public record WebExistedResourceResponse(
+	boolean isExist
+) {
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebJoinRequest.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebJoinRequest.java
@@ -1,11 +1,24 @@
 package com.tteokguk.tteokguk.member.presentation.dto;
 
+import org.hibernate.validator.constraints.Length;
+
 import com.tteokguk.tteokguk.member.application.dto.AppJoinRequest;
 
-// TODO: 요청 바디 검증이 필요하다.
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
 public record WebJoinRequest(
+	@NotNull(message = "이메일을 반드시 입력해주세요.")
+	@Pattern(
+		regexp = "^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$",
+		message = "이메일 형식을 지켜주세요.")
 	String email,
+	@Length(min = 8, max = 16, message = "비밀번호를 8 ~ 16글자로 입력해주세요.")
+	@Pattern(
+		regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).*",
+		message = "영문, 숫자, 특수문자가 반드시 조합되어야 합니다.")
 	String password,
+	@Length(min = 2, max = 6, message = "닉네임을 2 ~ 6글자로 입력해주세요.")
 	String nickname
 ) {
 

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebJoinRequest.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebJoinRequest.java
@@ -1,0 +1,14 @@
+package com.tteokguk.tteokguk.member.presentation.dto;
+
+import com.tteokguk.tteokguk.member.application.dto.AppJoinRequest;
+
+public record WebJoinRequest(
+	String email,
+	String password,
+	String nickname
+) {
+
+	public AppJoinRequest convert() {
+		return new AppJoinRequest(email, password, nickname);
+	}
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebJoinRequest.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebJoinRequest.java
@@ -2,6 +2,7 @@ package com.tteokguk.tteokguk.member.presentation.dto;
 
 import com.tteokguk.tteokguk.member.application.dto.AppJoinRequest;
 
+// TODO: 요청 바디 검증이 필요하다.
 public record WebJoinRequest(
 	String email,
 	String password,

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebJoinResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebJoinResponse.java
@@ -1,0 +1,6 @@
+package com.tteokguk.tteokguk.member.presentation.dto;
+
+public record WebJoinResponse(
+	Long id
+) {
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebJoinResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebJoinResponse.java
@@ -1,6 +1,17 @@
 package com.tteokguk.tteokguk.member.presentation.dto;
 
+import com.tteokguk.tteokguk.member.application.dto.AppJoinResponse;
+
 public record WebJoinResponse(
-	Long id
+	Long id,
+	String nickname,
+	String primaryIngredient
 ) {
+	public static WebJoinResponse of(AppJoinResponse response) {
+		return new WebJoinResponse(
+			response.id(),
+			response.nickname(),
+			response.primaryIngredient()
+		);
+	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/tteokguk/constants/Ingredient.java
+++ b/src/main/java/com/tteokguk/tteokguk/tteokguk/constants/Ingredient.java
@@ -1,5 +1,7 @@
 package com.tteokguk.tteokguk.tteokguk.constants;
 
+import java.util.Random;
+
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -18,4 +20,12 @@ public enum Ingredient {
 	PEPPER("후추");
 
 	private final String name;
+
+	public static Ingredient random() {
+		Random random = new Random();
+
+		Ingredient[] ingredients = Ingredient.values();
+		int randomIdx = random.nextInt(ingredients.length);
+		return ingredients[randomIdx];
+	}
 }


### PR DESCRIPTION
## Issue ticket link and number
- #10 

## Describe changes
- 회원가입 API를 구현하였습니다.
- 회원가입에 필요한 이메일 중복 체크, 닉네임 중복 체크 API를 구현하였습니다.
- `ErrorResponse` 클래스의 Json 직렬화가 되지 않는 버그를 수정했습니다.

## Notification for Reviewer
- 회원가입 시 전용 재료를 인벤토리를 넣을 때, stockQuantity를 10억을 INF로 정하여 넣었습니다. 그런데 굳이 전용 재료를 인벤토리에서 관리할 필요가 있을까라는 생각이 들었습니다. 인벤토리에 전용 재료를 넣은 후, 재고를 늘리거나 올릴 일이 없다고 생각합니다. 그래서 인벤토리에 전용 재료를 삽입하는 로직을 뺄까 생각하는데 어떻게 생각하시나요?

### 요약
1. 회원가입 시 인벤토리에 전용 재료를 넣는다.
2. 회원가입 시 인벤토리에 전용 재료를 넣지 않는다.

감사합니다.