### PR TITLE
[FEATURE] #12 예외에 대한 세부 응답 추가

### DIFF
--- a/src/main/java/com/tteokguk/tteokguk/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/exception/ApiExceptionHandler.java
@@ -21,7 +21,7 @@ public class ApiExceptionHandler {
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
-		return ErrorResponse.of(Optional.ofNullable(ex.getFieldError()));
+		return ErrorResponse.of(ex.getFieldErrors());
 	}
 
 	@ExceptionHandler(BusinessException.class)

--- a/src/main/java/com/tteokguk/tteokguk/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/exception/ApiExceptionHandler.java
@@ -1,7 +1,5 @@
 package com.tteokguk.tteokguk.global.exception;
 
-import java.util.Optional;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;

--- a/src/main/java/com/tteokguk/tteokguk/global/exception/error/ErrorResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/exception/error/ErrorResponse.java
@@ -3,8 +3,13 @@ package com.tteokguk.tteokguk.global.exception.error;
 import static com.tteokguk.tteokguk.global.exception.error.GlobalError.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 
 import lombok.Getter;
@@ -18,18 +23,32 @@ public class ErrorResponse {
 
 	private final String errorMessage;
 
-	private ErrorResponse(String errorCode, String errorMessage) {
+	private final Object details;
+
+	private ErrorResponse(String errorCode, String errorMessage, Object details) {
 		this.timeStamp = LocalDateTime.now().toString();
 		this.errorCode = errorCode;
 		this.errorMessage = errorMessage;
+		this.details = details;
 	}
 
 	public static ErrorResponse of(ErrorCode errorCode) {
-		return new ErrorResponse(errorCode.getCode(), errorCode.getMessage());
+		return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), null);
+	}
+
+	public static ErrorResponse of(ErrorCode errorCode, Object details) {
+		return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), details);
 	}
 
 	public static ErrorResponse of(Optional<FieldError> fieldError) {
-		return fieldError.map(error -> new ErrorResponse(error.getCode(), error.getDefaultMessage()))
+		return fieldError.map(error -> new ErrorResponse(error.getCode(), error.getDefaultMessage(), null))
 			.orElseGet(() -> ErrorResponse.of(INVALID_REQUEST_PARAM));
+	}
+
+	public static ErrorResponse of(List<FieldError> fieldErrors) {
+		Map<String, String> errors = fieldErrors.stream()
+			.collect(Collectors.toMap(FieldError::getField, err -> err.getDefaultMessage() == null ? "null" : err.getDefaultMessage()));
+
+		return ErrorResponse.of(INVALID_REQUEST_PARAM, errors);
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/global/exception/error/ErrorResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/exception/error/ErrorResponse.java
@@ -8,8 +8,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 
 import lombok.Getter;

--- a/src/main/java/com/tteokguk/tteokguk/global/exception/error/GlobalError.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/exception/error/GlobalError.java
@@ -11,8 +11,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum GlobalError implements ErrorCode {
 
-	GLOBAL_NOT_FOUND("Not Found", NOT_FOUND, "G_001"),
-	INVALID_REQUEST_PARAM("Invalid Request Parameter", BAD_REQUEST, "G_002");
+	GLOBAL_NOT_FOUND("리소스가 존재하지 않습니다.", NOT_FOUND, "G_001"),
+	INVALID_REQUEST_PARAM("요청 파라미터가 유효하지 않습니다.", BAD_REQUEST, "G_002");
 
 	private final String message;
 	private final HttpStatus status;


### PR DESCRIPTION
## Issue ticket link and number
- #12 

## Describe changes
- ErrorResponse에 details 필드를 추가하였습니다.
- 만약 회원가입에서 요청 파라미터가 유효하지 않을 시 다음과 같이 출력됩니다.
```json
{
    "timeStamp": "2024-01-22T16:40:46.550374400",
    "errorCode": "G_002",
    "errorMessage": "요청 파라미터가 유효하지 않습니다.",
    "details": {
        "password": "영문, 숫자, 특수문자가 반드시 조합되어야 합니다.",
        "nickname": "닉네임을 2 ~ 6글자로 입력해주세요.",
        "email": "이메일 형식을 지켜주세요."
    }
}
```
- GlobalError의 영어 메세지를 한글로 변경하였습니다.
- `Not Found` -> `리소스가 존재하지 않습니다.`
- `Invalid Request Parameter` -> `요청 파라미터가 유효하지 않습니다.`

## Notification for Reviewer
@h-beeen 