### PR TITLE
[FEATURE] 멤버 회원가입 간 최초 재고 로직

### DIFF
--- a/src/main/java/com/tteokguk/tteokguk/member/domain/Inventory.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/Inventory.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -42,7 +43,8 @@ public class Inventory {
 	@ManyToOne(fetch = LAZY)
 	private Member member;
 
-	public Inventory(
+	@Builder(access = PRIVATE)
+	private Inventory(
 		Ingredient ingredient,
 		int stockQuantity,
 		Member member
@@ -50,5 +52,17 @@ public class Inventory {
 		this.ingredient = ingredient;
 		this.stockQuantity = stockQuantity;
 		this.member = member;
+	}
+
+	public static Inventory create(
+		Ingredient ingredient,
+		int stockQuantity,
+		Member member
+	) {
+		return Inventory.builder()
+			.ingredient(ingredient)
+			.stockQuantity(stockQuantity)
+			.member(member)
+			.build();
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/SimpleMember.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/SimpleMember.java
@@ -5,8 +5,6 @@ import static lombok.AccessLevel.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.util.ObjectUtils;
-
 import com.tteokguk.tteokguk.tteokguk.constants.Ingredient;
 
 import jakarta.persistence.Column;
@@ -42,8 +40,9 @@ public class SimpleMember extends Member {
 	public static SimpleMember of(String email, String password, String nickname) {
 		Ingredient primaryIngredient = Ingredient.random();
 
-		SimpleMember entity = new SimpleMember(email, password, nickname, primaryIngredient, new ArrayList<>());
-		entity.initInventory(primaryIngredient);
-		return entity;
+		SimpleMember member = new SimpleMember(email, password, nickname, primaryIngredient, new ArrayList<>());
+
+		member.initializeInventory(primaryIngredient);
+		return member;
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/exception/MemberError.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/exception/MemberError.java
@@ -13,7 +13,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MemberError implements ErrorCode {
 
-	MEMBER_NOT_FOUND("해당 사용자를 찾을 수 없습니다.", NOT_FOUND, "M_001");
+	MEMBER_NOT_FOUND("해당 사용자를 찾을 수 없습니다.", NOT_FOUND, "M_001"),
+	MEMBER_INGREDIENT_EXCEPTION("식별할 수 없는 재료가 요청되었습니다.", BAD_REQUEST, "M_002");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/tteokguk/tteokguk/tteokguk/application/TteokgukService.java
+++ b/src/main/java/com/tteokguk/tteokguk/tteokguk/application/TteokgukService.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.tteokguk.tteokguk.global.exception.BusinessException;
 import com.tteokguk.tteokguk.member.domain.Member;
-import com.tteokguk.tteokguk.member.infra.persistence.MemberRepository;
+import com.tteokguk.tteokguk.member.infra.persistence.SimpleMemberRepository;
 import com.tteokguk.tteokguk.tteokguk.application.dto.request.CreateTteokgukRequest;
 import com.tteokguk.tteokguk.tteokguk.application.dto.response.CreateTteokgukResponse;
 import com.tteokguk.tteokguk.tteokguk.domain.Tteokguk;
@@ -20,19 +20,21 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TteokgukService {
 
-	private final MemberRepository memberRepository;
+	private final SimpleMemberRepository memberRepository;
 	private final TteokgukRepository tteokgukRepository;
 
 	public CreateTteokgukResponse createTteokguk(
+		String email,
 		CreateTteokgukRequest request
 	) {
-		Member member = memberRepository.findById(2L)
+		Member member = memberRepository.findByEmail(email)
 			.orElseThrow(() -> BusinessException.of(MEMBER_NOT_FOUND));
 
+		// 유저 재고 바탕 예외처리 및 재고 감산 로직 추가 예정
+		
 		Tteokguk tteokguk = Tteokguk.of(request.wish(), request.ingredients(), member);
 		Tteokguk savedTteokguk = tteokgukRepository.save(tteokguk);
 
-		// 유저 재고 바탕 예외처리 및 재고 감산 로직 추가 예정
 		return CreateTteokgukResponse.builder()
 			.tteokgukId(savedTteokguk.getId())
 			.memberId(savedTteokguk.getMember().getId())

--- a/src/main/java/com/tteokguk/tteokguk/tteokguk/presentation/TteokgukController.java
+++ b/src/main/java/com/tteokguk/tteokguk/tteokguk/presentation/TteokgukController.java
@@ -2,13 +2,13 @@ package com.tteokguk.tteokguk.tteokguk.presentation;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.tteokguk.tteokguk.member.domain.Member;
 import com.tteokguk.tteokguk.tteokguk.application.TteokgukService;
 import com.tteokguk.tteokguk.tteokguk.application.dto.request.CreateTteokgukRequest;
 import com.tteokguk.tteokguk.tteokguk.application.dto.response.CreateTteokgukResponse;
@@ -26,11 +26,10 @@ public class TteokgukController {
 
 	@PostMapping
 	public ResponseEntity<CreateTteokgukResponse> createTteokguk(
-		@AuthenticationPrincipal Member member,
+		@AuthenticationPrincipal UserDetails user,
 		@RequestBody @Validated CreateTteokgukRequest request
 	) {
-		log.warn("{}", member.getId());
-		CreateTteokgukResponse response = tteokgukService.createTteokguk(request);
+		CreateTteokgukResponse response = tteokgukService.createTteokguk(user.getUsername(), request);
 		return ResponseEntity.ok(response);
 	}
 }


### PR DESCRIPTION
## Issue ticket link and number
- #8 

## Describe changes
-
<img width="715" alt="스크린샷 2024-01-22 오후 7 45 09" src="https://github.com/tteokguk-please/tteokguk-api/assets/112257466/721fd3d4-9b3b-4422-9d2c-8df74c9ddd32">

- 멤버가 회원가입 할 때, Ingredient Enum에 포함되어 있는 모든 재고를 0, 고유 재료의 재고를 1억개로 add하는 로직 추가
- Spring Security를 활용해, 떡국 생성 로직에 최초 적용

## Notification for Reviewer
