### PR TITLE
[FIX] #34 로그인한 유저의 ID값이 스트링인 오류 해결

### DIFF
--- a/src/main/java/com/tteokguk/tteokguk/global/security/annotation/AuthId.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/security/annotation/AuthId.java
@@ -1,0 +1,14 @@
+package com.tteokguk.tteokguk.global.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : id")
+public @interface AuthId {
+}

--- a/src/main/java/com/tteokguk/tteokguk/global/security/jwt/Jwt.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/security/jwt/Jwt.java
@@ -13,6 +13,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 
 import com.tteokguk.tteokguk.global.exception.BusinessException;
+import com.tteokguk.tteokguk.global.security.model.CustomUser;
 import com.tteokguk.tteokguk.member.exception.AuthError;
 
 import io.jsonwebtoken.Claims;
@@ -90,7 +91,7 @@ public class Jwt {
 				.collect(Collectors.toList());
 
 		log.debug("claims subject := [{}]", claims.getSubject());
-		User principal = new User(claims.getSubject(), "", authorities);
+		User principal = new CustomUser(Long.parseLong(claims.getSubject()), claims.getSubject(), "", authorities);
 		return new UsernamePasswordAuthenticationToken(principal, this, authorities);
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/global/security/model/CustomUser.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/security/model/CustomUser.java
@@ -14,5 +14,6 @@ public class CustomUser extends User {
 
 	public CustomUser(Long id, String username, String password, Collection<? extends GrantedAuthority> authorities) {
 		super(username, password, authorities);
+		this.id = id;
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/global/security/model/CustomUser.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/security/model/CustomUser.java
@@ -1,0 +1,18 @@
+package com.tteokguk.tteokguk.global.security.model;
+
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import lombok.Getter;
+
+@Getter
+public class CustomUser extends User {
+
+	private Long id;
+
+	public CustomUser(Long id, String username, String password, Collection<? extends GrantedAuthority> authorities) {
+		super(username, password, authorities);
+	}
+}


### PR DESCRIPTION
## Issue ticket link and number
- #34 

## Describe changes
### Summary
- `@AuthenticationPrincipal CustomUser user`를 통해서 인증된 객체를 불러올 수 있습니다. 또한 위의 객체의 `getId()` 메서드를 통해 로그인한 유저의 PK 값을 알 수 있습니다.
- 커스텀 어노테이션 `@AuthId`를 구현했습니다. 파라미터에 `@AuthId Long id`를 통해 로그인한 유저의 ID를 쉽게 가져올 수 있습니다.

### Details
- 시큐리티의 User 클래스를 상속받은 CustomUser 클래스를 통해 Long 타입의 필드를 추가하였습니다.
- 사용자 접근 토큰으로 인가 후, 시큐리티 컨텍스트에 저장하는 인증 객체를 기존 User를 상속받은 CustomUser으로 등록합니다.
- `@AuthenticationPrincipal` 어노테이션을 통해 CustomUser 객체를 불러올 수 있습니다.
  ```java
  @GetMapping("/~")
  public ResponseEntity<?> getLoginUserInfo(@AuthenticationPrincipal CustomUser user) {
      Response loginUserInfo = userInfoService.getLoginUserInfo(user.getId());
      return ResponseEntity.ok(loginUserInfo);
  }
  ```
- `@AuthId` 어노테이션을 통해 로그인한 유저의 ID를 불러올 수 있습니다.
  ```java
  @GetMapping("/~")
  public ResponseEntity<?> getLoginUserInfo(@AuthId Long id) {
      Response loginUserInfo = userInfoService.getLoginUserInfo(id);
      return ResponseEntity.ok(loginUserInfo);
  }
  ```

## Notification for Reviewer
@h-beeen 

close #34 