### PR TITLE
[FEATURE] #41 임시 유저 초기화 API

### DIFF
--- a/src/main/java/com/tteokguk/tteokguk/global/security/SecurityConfig.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/security/SecurityConfig.java
@@ -51,7 +51,9 @@ public class SecurityConfig {
 	@Bean
 	@Order(1)
 	public SecurityFilterChain anyRequestFilterChain(HttpSecurity http) throws Exception {
-		http.authorizeHttpRequests(auth -> auth.anyRequest().hasRole("USER"))
+		http.authorizeHttpRequests(auth -> auth
+				.requestMatchers(customRequestMatcher.tempUserEndpoints()).hasRole("TEMP_USER")
+				.anyRequest().hasRole("USER"))
 			.addFilterAfter(customAuthorizationFilter, UsernamePasswordAuthenticationFilter.class)
 			.addFilterBefore(apiExceptionHandlingFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/tteokguk/tteokguk/global/security/matcher/CustomRequestMatcher.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/security/matcher/CustomRequestMatcher.java
@@ -22,4 +22,8 @@ public class CustomRequestMatcher {
 	public RequestMatcher serverInfoEndpoints() {
 		return new AntPathRequestMatcher("/actuator/info");
 	}
+
+	public RequestMatcher tempUserEndpoints() {
+		return new AntPathRequestMatcher("/api/v1/user/initialization");
+	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/application/AuthService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/AuthService.java
@@ -4,12 +4,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.tteokguk.tteokguk.global.exception.BusinessException;
-
 import com.tteokguk.tteokguk.member.application.dto.request.AppJoinRequest;
 import com.tteokguk.tteokguk.member.application.dto.response.AppJoinResponse;
 import com.tteokguk.tteokguk.member.domain.RoleType;
 import com.tteokguk.tteokguk.member.domain.SimpleMember;
-import com.tteokguk.tteokguk.member.exception.AuthError;
+import com.tteokguk.tteokguk.member.exception.MemberError;
 import com.tteokguk.tteokguk.member.infra.persistence.SimpleMemberRepository;
 
 import jakarta.transaction.Transactional;
@@ -27,10 +26,10 @@ public class AuthService {
 
 	public AppJoinResponse join(AppJoinRequest request) {
 		if (existsByEmail(request.email()))
-			throw new BusinessException(AuthError.DUPLICATE_EMAIL);
+			throw new BusinessException(MemberError.DUPLICATE_EMAIL);
 
 		if (existsByNickname(request.nickname()))
-			throw new BusinessException(AuthError.DUPLICATE_NICKNAME);
+			throw new BusinessException(MemberError.DUPLICATE_NICKNAME);
 
 		SimpleMember entity = simpleMemberRepository.save(
 			SimpleMember.of(

--- a/src/main/java/com/tteokguk/tteokguk/member/application/UserInfoService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/UserInfoService.java
@@ -6,6 +6,8 @@ import com.tteokguk.tteokguk.member.application.dto.response.MyPageResponse;
 import com.tteokguk.tteokguk.member.application.dto.response.UserInfoResponse;
 import com.tteokguk.tteokguk.member.application.dto.response.assembler.UserInfoResponseAssembler;
 import com.tteokguk.tteokguk.member.domain.Member;
+import com.tteokguk.tteokguk.member.exception.AuthError;
+import com.tteokguk.tteokguk.member.exception.MemberError;
 import com.tteokguk.tteokguk.member.infra.persistence.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -35,6 +37,9 @@ public class UserInfoService {
     }
 
     public void initialize(Long memberId, AppInitRequest request) {
+        if (memberRepository.existsByNickname(request.nickname()))
+            throw new BusinessException(MemberError.DUPLICATE_EMAIL);
+
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> BusinessException.of(MEMBER_NOT_FOUND));
 

--- a/src/main/java/com/tteokguk/tteokguk/member/application/UserInfoService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/UserInfoService.java
@@ -1,19 +1,21 @@
 package com.tteokguk.tteokguk.member.application;
 
+import static com.tteokguk.tteokguk.member.exception.MemberError.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.tteokguk.tteokguk.global.exception.BusinessException;
 import com.tteokguk.tteokguk.member.application.dto.request.AppInitRequest;
+import com.tteokguk.tteokguk.member.application.dto.response.AppInitResponse;
 import com.tteokguk.tteokguk.member.application.dto.response.MyPageResponse;
 import com.tteokguk.tteokguk.member.application.dto.response.UserInfoResponse;
 import com.tteokguk.tteokguk.member.application.dto.response.assembler.UserInfoResponseAssembler;
 import com.tteokguk.tteokguk.member.domain.Member;
-import com.tteokguk.tteokguk.member.exception.AuthError;
 import com.tteokguk.tteokguk.member.exception.MemberError;
 import com.tteokguk.tteokguk.member.infra.persistence.MemberRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import static com.tteokguk.tteokguk.member.exception.MemberError.MEMBER_NOT_FOUND;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional
@@ -36,7 +38,7 @@ public class UserInfoService {
         return UserInfoResponseAssembler.transferToUserInfoResponse(member);
     }
 
-    public void initialize(Long memberId, AppInitRequest request) {
+    public AppInitResponse initialize(Long memberId, AppInitRequest request) {
         if (memberRepository.existsByNickname(request.nickname()))
             throw new BusinessException(MemberError.DUPLICATE_EMAIL);
 
@@ -44,5 +46,7 @@ public class UserInfoService {
             .orElseThrow(() -> BusinessException.of(MEMBER_NOT_FOUND));
 
         member.initialize(request.nickname(), request.acceptsMarketing());
+
+        return AppInitResponse.of(member);
     }
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/application/UserInfoService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/UserInfoService.java
@@ -1,6 +1,7 @@
 package com.tteokguk.tteokguk.member.application;
 
 import com.tteokguk.tteokguk.global.exception.BusinessException;
+import com.tteokguk.tteokguk.member.application.dto.request.AppInitRequest;
 import com.tteokguk.tteokguk.member.application.dto.response.MyPageResponse;
 import com.tteokguk.tteokguk.member.application.dto.response.UserInfoResponse;
 import com.tteokguk.tteokguk.member.application.dto.response.assembler.UserInfoResponseAssembler;
@@ -31,5 +32,12 @@ public class UserInfoService {
                 .orElseThrow(() -> BusinessException.of(MEMBER_NOT_FOUND));
 
         return UserInfoResponseAssembler.transferToUserInfoResponse(member);
+    }
+
+    public void initialize(Long memberId, AppInitRequest request) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> BusinessException.of(MEMBER_NOT_FOUND));
+
+        member.initialize(request.nickname(), request.acceptsMarketing());
     }
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/application/dto/request/AppInitRequest.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/dto/request/AppInitRequest.java
@@ -1,0 +1,7 @@
+package com.tteokguk.tteokguk.member.application.dto.request;
+
+public record AppInitRequest(
+	String nickname,
+	Boolean acceptsMarketing
+) {
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/application/dto/response/AppInitResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/dto/response/AppInitResponse.java
@@ -1,0 +1,17 @@
+package com.tteokguk.tteokguk.member.application.dto.response;
+
+import com.tteokguk.tteokguk.member.domain.Member;
+
+public record AppInitResponse(
+	Long id,
+	String nickname,
+	String primaryIngredient
+) {
+	public static AppInitResponse of(Member entity) {
+		return new AppInitResponse(
+			entity.getId(),
+			entity.getNickname(),
+			entity.getPrimaryIngredient().name()
+		);
+	}
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/Member.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/Member.java
@@ -116,9 +116,6 @@ public class Member extends BaseEntity {
 	}
 
 	public void initialize(String nickname, Boolean acceptsMarketing) {
-		if (this.role == RoleType.ROLE_TEMP_USER)
-			throw new BusinessException(MemberError.NOT_TEMP_USER);
-
 		this.nickname = nickname;
 		this.acceptsMarketing = acceptsMarketing;
 		this.role = RoleType.ROLE_USER;

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/Member.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/Member.java
@@ -13,6 +13,8 @@ import java.util.List;
 import org.hibernate.annotations.OnDelete;
 
 import com.tteokguk.tteokguk.global.auditing.BaseEntity;
+import com.tteokguk.tteokguk.global.exception.BusinessException;
+import com.tteokguk.tteokguk.member.exception.MemberError;
 import com.tteokguk.tteokguk.tteokguk.constants.Ingredient;
 import com.tteokguk.tteokguk.tteokguk.domain.Tteokguk;
 
@@ -111,5 +113,14 @@ public class Member extends BaseEntity {
 
 	public void addTteokguk(Tteokguk tteokguk) {
 		this.tteokguks.add(tteokguk);
+	}
+
+	public void initialize(String nickname, Boolean acceptsMarketing) {
+		if (this.role == RoleType.ROLE_TEMP_USER)
+			throw new BusinessException(MemberError.NOT_TEMP_USER);
+
+		this.nickname = nickname;
+		this.acceptsMarketing = acceptsMarketing;
+		this.role = RoleType.ROLE_USER;
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/exception/AuthError.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/exception/AuthError.java
@@ -11,8 +11,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum AuthError implements ErrorCode {
 
-	DUPLICATE_EMAIL("이메일이 중복되었습니다.", HttpStatus.BAD_REQUEST, "A_001"),
-	DUPLICATE_NICKNAME("닉네임이 중복되었습니다.", HttpStatus.BAD_REQUEST, "A_002"),
 	BAD_EMAIL("잘못된 이메일입니다.", HttpStatus.UNAUTHORIZED, "A_003"),
 	BAD_PASSWORD("잘못된 비밀번호입니다.", HttpStatus.UNAUTHORIZED, "A_004"),
 	INVALID_JWT_SIGNATURE("시그니처가 유효하지 않습니다.", HttpStatus.UNAUTHORIZED, "A_005"),

--- a/src/main/java/com/tteokguk/tteokguk/member/exception/MemberError.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/exception/MemberError.java
@@ -15,6 +15,8 @@ public enum MemberError implements ErrorCode {
 
 	MEMBER_NOT_FOUND("해당 사용자를 찾을 수 없습니다.", NOT_FOUND, "M_001"),
 	NOT_TEMP_USER("해당 사용자는 임시 유저가 아닙니다.", BAD_REQUEST, "M_002"),
+	DUPLICATE_EMAIL("이메일이 중복되었습니다.", BAD_REQUEST, "M_003"),
+	DUPLICATE_NICKNAME("닉네임이 중복되었습니다.", BAD_REQUEST, "M_004"),
 	;
 
 	private final String message;

--- a/src/main/java/com/tteokguk/tteokguk/member/exception/MemberError.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/exception/MemberError.java
@@ -13,7 +13,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MemberError implements ErrorCode {
 
-	MEMBER_NOT_FOUND("해당 사용자를 찾을 수 없습니다.", NOT_FOUND, "M_001");
+	MEMBER_NOT_FOUND("해당 사용자를 찾을 수 없습니다.", NOT_FOUND, "M_001"),
+	NOT_TEMP_USER("해당 사용자는 임시 유저가 아닙니다.", BAD_REQUEST, "M_002"),
+	;
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/tteokguk/tteokguk/member/exception/MemberError.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/exception/MemberError.java
@@ -14,9 +14,8 @@ import lombok.RequiredArgsConstructor;
 public enum MemberError implements ErrorCode {
 
 	MEMBER_NOT_FOUND("해당 사용자를 찾을 수 없습니다.", NOT_FOUND, "M_001"),
-	NOT_TEMP_USER("해당 사용자는 임시 유저가 아닙니다.", BAD_REQUEST, "M_002"),
-	DUPLICATE_EMAIL("이메일이 중복되었습니다.", BAD_REQUEST, "M_003"),
-	DUPLICATE_NICKNAME("닉네임이 중복되었습니다.", BAD_REQUEST, "M_004"),
+	DUPLICATE_EMAIL("이메일이 중복되었습니다.", BAD_REQUEST, "M_002"),
+	DUPLICATE_NICKNAME("닉네임이 중복되었습니다.", BAD_REQUEST, "M_003"),
 	;
 
 	private final String message;

--- a/src/main/java/com/tteokguk/tteokguk/member/infra/persistence/MemberRepository.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/infra/persistence/MemberRepository.java
@@ -7,4 +7,5 @@ import com.tteokguk.tteokguk.member.domain.Member;
 
 @Transactional
 public interface MemberRepository extends JpaRepository<Member, Long> {
+	boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/UserInfoController.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/UserInfoController.java
@@ -1,8 +1,11 @@
 package com.tteokguk.tteokguk.member.presentation;
 
+import com.tteokguk.tteokguk.global.security.annotation.AuthId;
 import com.tteokguk.tteokguk.member.application.UserInfoService;
 import com.tteokguk.tteokguk.member.application.dto.response.MyPageResponse;
 import com.tteokguk.tteokguk.member.application.dto.response.UserInfoResponse;
+import com.tteokguk.tteokguk.member.presentation.dto.WebInitRequest;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -24,5 +27,11 @@ public class UserInfoController {
     public ResponseEntity<UserInfoResponse> getUserInfo(@PathVariable Long userId) {
         UserInfoResponse userInfo = userInfoService.getUserInfo(userId);
         return ResponseEntity.ok(userInfo);
+    }
+
+    @PostMapping("/initialization")
+    public ResponseEntity<Void> initialize(@AuthId Long id, @RequestBody WebInitRequest request) {
+        userInfoService.initialize(id, request.convert());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/UserInfoController.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/UserInfoController.java
@@ -2,9 +2,11 @@ package com.tteokguk.tteokguk.member.presentation;
 
 import com.tteokguk.tteokguk.global.security.annotation.AuthId;
 import com.tteokguk.tteokguk.member.application.UserInfoService;
+import com.tteokguk.tteokguk.member.application.dto.response.AppInitResponse;
 import com.tteokguk.tteokguk.member.application.dto.response.MyPageResponse;
 import com.tteokguk.tteokguk.member.application.dto.response.UserInfoResponse;
 import com.tteokguk.tteokguk.member.presentation.dto.WebInitRequest;
+import com.tteokguk.tteokguk.member.presentation.dto.WebInitResponse;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -30,8 +32,8 @@ public class UserInfoController {
     }
 
     @PostMapping("/initialization")
-    public ResponseEntity<Void> initialize(@AuthId Long id, @RequestBody WebInitRequest request) {
-        userInfoService.initialize(id, request.convert());
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<WebInitResponse> initialize(@AuthId Long id, @RequestBody WebInitRequest request) {
+        AppInitResponse response = userInfoService.initialize(id, request.convert());
+        return ResponseEntity.ok(WebInitResponse.of(response));
     }
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebInitRequest.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebInitRequest.java
@@ -1,0 +1,21 @@
+package com.tteokguk.tteokguk.member.presentation.dto;
+
+import org.hibernate.validator.constraints.Length;
+
+import com.tteokguk.tteokguk.member.application.dto.request.AppInitRequest;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record WebInitRequest(
+	@Length(min = 2, max = 6, message = "닉네임을 2 ~ 6글자로 입력해주세요.")
+	String nickname,
+	@NotNull(message = "해당 필드는 필수값입니다.")
+	@Pattern(regexp = "true|false", message = "true 혹은 false로 입력해주세요.")
+	String acceptsMarketing
+) {
+
+	public AppInitRequest convert() {
+		return new AppInitRequest(nickname, Boolean.valueOf(acceptsMarketing));
+	}
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebInitResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebInitResponse.java
@@ -1,0 +1,17 @@
+package com.tteokguk.tteokguk.member.presentation.dto;
+
+import com.tteokguk.tteokguk.member.application.dto.response.AppInitResponse;
+
+public record WebInitResponse(
+	Long id,
+	String nickname,
+	String primaryIngredient
+) {
+	public static WebInitResponse of(AppInitResponse response) {
+		return new WebInitResponse(
+			response.id(),
+			response.nickname(),
+			response.primaryIngredient()
+		);
+	}
+}


### PR DESCRIPTION
## Issue ticket link and number
- #41 

## Describe changes
- 임시 유저의 닉네임, 마케팅 활용 정보 동의를 받아 `TEMP_USER` 권한에서 `USER` 권한으로 업데이트합니다.
- 응답은 회원 가입때와 같이 멤버의 ID, 닉네임, 전용 재료가 응답됩니다.
- AuthError의 이메일 중복, 닉네임 중복을 MemberError로 옮겼습니다. -> 회원가입때만 사용되는 것이 아니라 초기화 과정에도 사용이 되고, 닉네임 변경 등의 서비스에서 사용할 수 있으리라 판단하여 수정했습니다.

## Notification for Reviewer
@h-beeen 

close #41 