### PR TITLE
feat: 받은 떡국 조회 페이징 API / 떡국 삭제 API

### DIFF
--- a/src/main/java/com/tteokguk/tteokguk/global/dto/response/ApiPageResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/dto/response/ApiPageResponse.java
@@ -1,0 +1,59 @@
+package com.tteokguk.tteokguk.global.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@Slf4j
+@Getter
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiPageResponse<T> {
+
+    private List<T> data;
+    private PageInfo pageInfo;
+
+    @Builder
+    private ApiPageResponse(Page<T> data) {
+        this.data = data.getContent();
+        this.pageInfo = PageInfo.of(data.getPageable(), data.getTotalPages());
+    }
+
+    public static <T> ApiPageResponse<T> of(Page<T> data) {
+        return ApiPageResponse.<T>builder()
+                .data(data)
+                .build();
+    }
+
+    @Getter
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class PageInfo {
+        private Integer page;
+        private Integer size;
+
+        @Builder
+        private PageInfo(
+                Pageable pageable,
+                Integer page
+        ) {
+            this.page = page;
+            this.size = pageable.getPageSize();
+        }
+
+        public static PageInfo of(
+                Pageable pageable,
+                Integer page
+        ) {
+            return PageInfo.builder()
+                    .pageable(pageable)
+                    .page(page)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/tteokguk/tteokguk/support/application/SupportService.java
+++ b/src/main/java/com/tteokguk/tteokguk/support/application/SupportService.java
@@ -5,18 +5,28 @@ import com.tteokguk.tteokguk.global.exception.BusinessException;
 import com.tteokguk.tteokguk.member.domain.Member;
 import com.tteokguk.tteokguk.member.infra.persistence.MemberRepository;
 import com.tteokguk.tteokguk.support.application.dto.SupportRequest;
+import com.tteokguk.tteokguk.support.application.dto.request.SupportPageableRequest;
+import com.tteokguk.tteokguk.support.application.dto.response.ReceivedIngredientResponse;
 import com.tteokguk.tteokguk.support.application.dto.response.SupportResponse;
 import com.tteokguk.tteokguk.support.application.dto.response.assembler.SupportResponseAssembler;
 import com.tteokguk.tteokguk.support.domain.Support;
+import com.tteokguk.tteokguk.support.infra.persistence.SupportQueryRepository;
 import com.tteokguk.tteokguk.support.infra.persistence.SupportRepository;
 import com.tteokguk.tteokguk.tteokguk.domain.Tteokguk;
 import com.tteokguk.tteokguk.tteokguk.infra.persistence.TteokgukRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static com.tteokguk.tteokguk.member.exception.MemberError.MEMBER_NOT_FOUND;
 import static com.tteokguk.tteokguk.tteokguk.exception.TteokgukError.TTEOKGUK_NOT_FOUND;
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @Service
 @Transactional
@@ -26,6 +36,7 @@ public class SupportService {
     private final SupportRepository supportRepository;
     private final MemberRepository memberRepository;
     private final TteokgukRepository tteokgukRepository;
+    private final SupportQueryRepository supportQueryRepository;
 
     public SupportResponse doSupport(
             Long id,
@@ -43,8 +54,21 @@ public class SupportService {
                 sender, receiver, supportedTteokguk,
                 request.supportIngredient(), request.access(), request.message()
         );
-        
+
         Support savedSupport = supportRepository.save(support);
-        return SupportResponseAssembler.toSupportResponse(savedSupport);
+        return SupportResponseAssembler.toSupportResponse(savedSupport); // 공개여부!!
+    }
+
+    public Page<ReceivedIngredientResponse> getReceivedIngredientResponse(
+            Long id,
+            SupportPageableRequest request
+    ) {
+        PageRequest pageable = PageRequest.of(
+                request.page() - 1,
+                request.size(),
+                Sort.by(DESC, "support_id"));
+
+        List<ReceivedIngredientResponse> responses = supportQueryRepository.getReceivedIngredientResponse(id, pageable);
+        return new PageImpl<>(responses, pageable, responses.size());
     }
 }

--- a/src/main/java/com/tteokguk/tteokguk/support/application/dto/request/SupportPageableRequest.java
+++ b/src/main/java/com/tteokguk/tteokguk/support/application/dto/request/SupportPageableRequest.java
@@ -1,0 +1,21 @@
+package com.tteokguk.tteokguk.support.application.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record SupportPageableRequest(
+        @Positive(message = "페이지 번호는 양수입니다.")
+        @NotNull(message = "페이지 번호는 필수입니다.")
+        Integer page,
+
+        @Min(value = 1, message = "페이지 수는 최소 1개 이상입니다.")
+        @NotNull(message = "페이지 수는 필수입니다.")
+        Integer size,
+        
+        @Min(value = 1, message = "페이지 번호 목록 갯수는 최소 1개 이상 입니다.")
+        @Max(value = 10, message = "페이지 번호 목록 갯수는 최대 10개 입니다.")
+        Integer count
+) {
+}

--- a/src/main/java/com/tteokguk/tteokguk/support/application/dto/response/ReceivedIngredientResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/support/application/dto/response/ReceivedIngredientResponse.java
@@ -1,13 +1,13 @@
 package com.tteokguk.tteokguk.support.application.dto.response;
 
 import com.tteokguk.tteokguk.tteokguk.constants.Ingredient;
-import lombok.Builder;
 
-@Builder
-public record SupportResponse(
+public record ReceivedIngredientResponse(
         Long id,
-        Ingredient rewardIngredient,
-        int rewardQuantity,
+        Long senderId,
+        String nickname,
+        Ingredient ingredient,
+        String message,
         boolean access
 ) {
 }

--- a/src/main/java/com/tteokguk/tteokguk/support/application/dto/response/assembler/SupportResponseAssembler.java
+++ b/src/main/java/com/tteokguk/tteokguk/support/application/dto/response/assembler/SupportResponseAssembler.java
@@ -13,6 +13,7 @@ public class SupportResponseAssembler {
                 .id(support.getId())
                 .rewardIngredient(support.getRewardIngredient())
                 .rewardQuantity(support.getRewardQuantity())
+                .access(support.isAccess())
                 .build();
     }
 }

--- a/src/main/java/com/tteokguk/tteokguk/support/infra/persistence/SupportQueryRepository.java
+++ b/src/main/java/com/tteokguk/tteokguk/support/infra/persistence/SupportQueryRepository.java
@@ -1,0 +1,58 @@
+package com.tteokguk.tteokguk.support.infra.persistence;
+
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tteokguk.tteokguk.support.application.dto.response.ReceivedIngredientResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.tteokguk.tteokguk.support.domain.QSupport.support;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class SupportQueryRepository {
+
+    private final JPAQueryFactory query;
+
+    public List<ReceivedIngredientResponse> getReceivedIngredientResponse(
+            Long id,
+            Pageable pageable
+    ) {
+        List<Long> supportIds = getSupportIds(id, pageable);
+
+        return query
+                .select(getReceivedIngredientResponseConstructorExpression())
+                .from(support)
+                .where(support.id.in(supportIds))
+                .orderBy(support.id.desc())
+                .fetch();
+    }
+
+    public List<Long> getSupportIds(Long id, Pageable pageable) {
+        return query.select(support.id)
+                .from(support)
+                .where(support.receiver.id.eq(id))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(support.id.desc())
+                .fetch();
+    }
+
+    private ConstructorExpression<ReceivedIngredientResponse> getReceivedIngredientResponseConstructorExpression() {
+        return Projections.constructor(
+                ReceivedIngredientResponse.class,
+                support.id,
+                support.sender.id,
+                support.sender.nickname,
+                support.supportIngredient,
+                support.message,
+                support.access
+        );
+    }
+}

--- a/src/main/java/com/tteokguk/tteokguk/support/presentation/SupportController.java
+++ b/src/main/java/com/tteokguk/tteokguk/support/presentation/SupportController.java
@@ -1,16 +1,18 @@
 package com.tteokguk.tteokguk.support.presentation;
 
+import com.tteokguk.tteokguk.global.dto.response.ApiPageResponse;
 import com.tteokguk.tteokguk.global.security.annotation.AuthId;
 import com.tteokguk.tteokguk.support.application.SupportService;
 import com.tteokguk.tteokguk.support.application.dto.SupportRequest;
+import com.tteokguk.tteokguk.support.application.dto.request.SupportPageableRequest;
+import com.tteokguk.tteokguk.support.application.dto.response.ReceivedIngredientResponse;
 import com.tteokguk.tteokguk.support.application.dto.response.SupportResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,5 +28,15 @@ public class SupportController {
     ) {
         SupportResponse response = supportService.doSupport(id, request);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/ingredient")
+    public ResponseEntity<ApiPageResponse<ReceivedIngredientResponse>> getReceivedIngredientResponse(
+            @AuthId Long id,
+            @Valid SupportPageableRequest request
+    ) {
+        Page<ReceivedIngredientResponse> pagedResponse = supportService.getReceivedIngredientResponse(id, request);
+        ApiPageResponse<ReceivedIngredientResponse> pagedApiResponse = ApiPageResponse.of(pagedResponse);
+        return ResponseEntity.ok(pagedApiResponse);
     }
 }

--- a/src/main/java/com/tteokguk/tteokguk/tteokguk/application/TteokgukService.java
+++ b/src/main/java/com/tteokguk/tteokguk/tteokguk/application/TteokgukService.java
@@ -43,6 +43,21 @@ public class TteokgukService {
         return TteokgukResponseAssembler.toTteokgukResponse(savedTteokguk);
     }
 
+    public void deleteTteokguk(
+            Long id,
+            Long tteokgukId
+    ) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> BusinessException.of(MEMBER_NOT_FOUND));
+
+        Tteokguk tteokguk = member.getTteokguks().stream()
+                .filter(t -> t.getId().equals(tteokgukId))
+                .findFirst()
+                .orElseThrow(() -> BusinessException.of(NOT_OWNER));
+
+        tteokguk.delete();
+    }
+
     public TteokgukResponse useIngredients(
             Long id,
             IngredientRequest request

--- a/src/main/java/com/tteokguk/tteokguk/tteokguk/presentation/TteokgukController.java
+++ b/src/main/java/com/tteokguk/tteokguk/tteokguk/presentation/TteokgukController.java
@@ -8,10 +8,7 @@ import com.tteokguk.tteokguk.tteokguk.application.dto.response.TteokgukResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,6 +24,15 @@ public class TteokgukController {
     ) {
         TteokgukResponse response = tteokgukService.createTteokguk(id, request);
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{tteokgukId}")
+    public ResponseEntity<Void> deleteTteokguk(
+            @AuthId Long id,
+            @PathVariable Long tteokgukId
+    ) {
+        tteokgukService.deleteTteokguk(id, tteokgukId);
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/use")


### PR DESCRIPTION
## Issue ticket link and number
- #8 
- #45 

## Describe changes
- 받은 떡국 조회에 대한 페이징 API를 제공합니다.

```json
{
    "data": [
        {
            "id": 160,
            "senderId": 2,
            "nickname": "야후!",
            "ingredient": "RICE_CAKE",
            "message": "야호!",
            "access": false
        },
        {
            "id": 159,
            "senderId": 2,
            "nickname": "야후!",
            "ingredient": "RICE_CAKE",
            "message": "야호!",
            "access": false
        },
        {
            "id": 158,
            "senderId": 2,
            "nickname": "야후!",
            "ingredient": "RICE_CAKE",
            "message": "야호!",
            "access": false
        }
    ],
    "pageInfo": {
        "page": 20,
        "size": 3
    }
}
```

- 떡국 soft Delete API를 제공합니다.

## Notification for Reviewer
