### PR TITLE
[FEATURE] #44 토큰 재발급 API 생성

### DIFF
--- a/src/main/java/com/tteokguk/tteokguk/global/security/jwt/JwtService.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/security/jwt/JwtService.java
@@ -1,0 +1,42 @@
+package com.tteokguk.tteokguk.global.security.jwt;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+import org.springframework.stereotype.Service;
+
+import com.tteokguk.tteokguk.global.utils.LocalDateTimeUtils;
+import com.tteokguk.tteokguk.member.domain.Member;
+import com.tteokguk.tteokguk.member.domain.RefreshToken;
+import com.tteokguk.tteokguk.member.infra.persistence.RefreshTokenRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class JwtService {
+
+	private final JwtFactory jwtFactory;
+	private final RefreshTokenRepository refreshTokenRepository;
+
+	public Jwt getAccessToken(Member member, Long now) {
+		return jwtFactory.createAuthToken(
+			String.valueOf(member.getId()), member.getRole().name(), new Date(jwtFactory.getExpiryOfAccessToken(now))
+		);
+	}
+
+	public Jwt getRefreshToken(Member member, Long now) {
+		Long expiry = jwtFactory.getExpiryOfRefreshToken(now);
+		Jwt refreshToken = jwtFactory.createAuthToken(null, new Date(expiry));
+		String encodedBody = refreshToken.getEncodedBody();
+		LocalDateTime expiryDateTime = LocalDateTimeUtils.convertBy(expiry);
+
+		RefreshToken entity = refreshTokenRepository.findByMember(member)
+			.orElseGet(() -> new RefreshToken(member, encodedBody, expiryDateTime));
+		entity.update(encodedBody, expiryDateTime);
+		refreshTokenRepository.save(entity);
+		return refreshToken;
+	}
+}

--- a/src/main/java/com/tteokguk/tteokguk/global/security/jwt/JwtService.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/security/jwt/JwtService.java
@@ -39,4 +39,8 @@ public class JwtService {
 		refreshTokenRepository.save(entity);
 		return refreshToken;
 	}
+
+	public void validate(String encodedBody) {
+		jwtFactory.convertAuthToken(encodedBody).getTokenClaims();
+	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/global/utils/LocalDateTimeUtils.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/utils/LocalDateTimeUtils.java
@@ -1,0 +1,13 @@
+package com.tteokguk.tteokguk.global.utils;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+public class LocalDateTimeUtils {
+	public static LocalDateTime convertBy(Long timestamp) {
+		return LocalDateTime.ofInstant(
+			Instant.ofEpochMilli(timestamp), ZoneId.systemDefault()
+		);
+	}
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/application/OAuthService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/OAuthService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import com.tteokguk.tteokguk.global.security.jwt.Jwt;
 import com.tteokguk.tteokguk.global.security.jwt.JwtFactory;
+import com.tteokguk.tteokguk.global.security.jwt.JwtService;
 import com.tteokguk.tteokguk.member.application.dto.response.AppOAuthLoginResponse;
 import com.tteokguk.tteokguk.member.domain.OAuthMember;
 import com.tteokguk.tteokguk.member.domain.ProviderType;
@@ -27,7 +28,7 @@ public class OAuthService {
 
 	private final OAuthHttpRequestHelper oAuthHttpRequestHelper;
 	private final OAuthMemberRepository oAuthMemberRepository;
-	private final JwtFactory jwtFactory;
+	private final JwtService jwtService;
 
 	public AppOAuthLoginResponse getByAuthorizationCode(ProviderType providerType, String code) {
 		TokenResponse tokenResponse = oAuthHttpRequestHelper.exchangeToken(providerType, code);
@@ -60,17 +61,11 @@ public class OAuthService {
 
 	private AppOAuthLoginResponse createResponse(OAuthMember member) {
 		Long now = System.currentTimeMillis();
-		Long expiryOfAccessToken = jwtFactory.getExpiryOfAccessToken(now);
-		Long expiryOfRefreshToken = jwtFactory.getExpiryOfRefreshToken(now);
-		Jwt accessToken = jwtFactory.createAuthToken(
-			String.valueOf(member.getId()), member.getRole().name(), new Date(expiryOfAccessToken)
-		);
-		Jwt refreshToken = jwtFactory.createAuthToken(null, new Date(expiryOfRefreshToken));
 
 		return new AppOAuthLoginResponse(
 			member.getId(),
-			accessToken.getEncodedBody(),
-			refreshToken.getEncodedBody(),
+			jwtService.getAccessToken(member, now).getEncodedBody(),
+			jwtService.getRefreshToken(member, now).getEncodedBody(),
 			member.getRole() == RoleType.ROLE_USER
 		);
 	}

--- a/src/main/java/com/tteokguk/tteokguk/member/application/RefreshTokenService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/RefreshTokenService.java
@@ -1,11 +1,17 @@
 package com.tteokguk.tteokguk.member.application;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
+import java.util.Date;
 
 import org.springframework.stereotype.Service;
 
+import com.tteokguk.tteokguk.global.exception.BusinessException;
+import com.tteokguk.tteokguk.global.security.jwt.Jwt;
+import com.tteokguk.tteokguk.global.security.jwt.JwtFactory;
+import com.tteokguk.tteokguk.global.utils.LocalDateTimeUtils;
+import com.tteokguk.tteokguk.member.domain.Member;
 import com.tteokguk.tteokguk.member.domain.RefreshToken;
+import com.tteokguk.tteokguk.member.exception.AuthError;
 import com.tteokguk.tteokguk.member.infra.persistence.RefreshTokenRepository;
 
 import jakarta.transaction.Transactional;
@@ -17,12 +23,32 @@ import lombok.RequiredArgsConstructor;
 public class RefreshTokenService {
 
 	private final RefreshTokenRepository refreshTokenRepository;
+	private final JwtFactory jwtFactory;
 
-	public void save(String token, Long memberId, LocalDateTime expiredDateTime) {
-		RefreshToken entity = refreshTokenRepository.findByMemberId(memberId)
-			.orElseGet(() -> new RefreshToken(memberId, token, expiredDateTime));
+	public void save(String token, Member member, LocalDateTime expiredDateTime) {
+		RefreshToken entity = refreshTokenRepository.findByMember(member)
+			.orElseGet(() -> new RefreshToken(member, token, expiredDateTime));
 		entity.update(token, expiredDateTime);
 		refreshTokenRepository.save(entity);
 	}
 
+	public String issueRefreshToken(String refreshToken) {
+		RefreshToken entity = refreshTokenRepository.findByToken(refreshToken)
+			.orElseThrow(() -> new BusinessException(AuthError.UNSUPPORTED_JWT_TOKEN));
+
+		Long expiry = jwtFactory.getExpiryOfRefreshToken(System.currentTimeMillis());
+		Jwt newToken = jwtFactory.createAuthToken(null, new Date(expiry));
+		save(newToken.getEncodedBody(), entity.getMember(), LocalDateTimeUtils.convertBy(expiry));
+		return newToken.getEncodedBody();
+	}
+
+	public String issueAccessToken(String refreshToken) {
+		RefreshToken entity = refreshTokenRepository.findByToken(refreshToken)
+			.orElseThrow(() -> new BusinessException(AuthError.UNSUPPORTED_JWT_TOKEN));
+
+		Member member = entity.getMember();
+		Long expiry = jwtFactory.getExpiryOfAccessToken(System.currentTimeMillis());
+		return jwtFactory.createAuthToken(String.valueOf(member.getId()), member.getRole().name(), new Date(expiry))
+			.getEncodedBody();
+	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/application/RefreshTokenService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/RefreshTokenService.java
@@ -21,8 +21,14 @@ public class RefreshTokenService {
 	private final JwtService jwtService;
 
 	public AppIssuedTokensResponse issueTokens(String refreshToken) {
+		try {
+			jwtService.validate(refreshToken);
+		} catch (BusinessException e) {
+			throw new BusinessException(AuthError.UNUSABLE_TOKEN);
+		}
+
 		RefreshToken entity = refreshTokenRepository.findByToken(refreshToken)
-			.orElseThrow(() -> new BusinessException(AuthError.UNSUPPORTED_JWT_TOKEN));
+			.orElseThrow(() -> new BusinessException(AuthError.UNUSABLE_TOKEN));
 
 		long currentTimeMillis = System.currentTimeMillis();
 		String issuedAccessToken = issueAccessToken(entity, currentTimeMillis);

--- a/src/main/java/com/tteokguk/tteokguk/member/application/RefreshTokenService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/RefreshTokenService.java
@@ -1,0 +1,28 @@
+package com.tteokguk.tteokguk.member.application;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.tteokguk.tteokguk.member.domain.RefreshToken;
+import com.tteokguk.tteokguk.member.infra.persistence.RefreshTokenRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+	private final RefreshTokenRepository refreshTokenRepository;
+
+	public void save(String token, Long memberId, LocalDateTime expiredDateTime) {
+		RefreshToken entity = refreshTokenRepository.findByMemberId(memberId)
+			.orElseGet(() -> new RefreshToken(memberId, token, expiredDateTime));
+		entity.update(token, expiredDateTime);
+		refreshTokenRepository.save(entity);
+	}
+
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/application/dto/response/AppIssuedTokensResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/dto/response/AppIssuedTokensResponse.java
@@ -1,0 +1,8 @@
+package com.tteokguk.tteokguk.member.application.dto.response;
+
+public record AppIssuedTokensResponse(
+	Long id,
+	String accessToken,
+	String refreshToken
+) {
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/RefreshToken.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/RefreshToken.java
@@ -1,0 +1,37 @@
+package com.tteokguk.tteokguk.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+	@Id
+	@GeneratedValue
+	@Column(name = "rt_id")
+	private Long id;
+
+	@Column(name = "member_id", nullable = false, unique = true)
+	private Long memberId;
+
+	@Column(name = "token", nullable = false, unique = true)
+	private String token;
+
+	@Builder
+	public RefreshToken(Long memberId, String token) {
+		this.memberId = memberId;
+		this.token = token;
+	}
+
+	public void update(String token) {
+		this.token = token;
+	}
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/RefreshToken.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/RefreshToken.java
@@ -4,10 +4,12 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,8 +23,9 @@ public class RefreshToken {
 	@Column(name = "rt_id")
 	private Long id;
 
-	@Column(name = "member_id", nullable = false, unique = true)
-	private Long memberId;
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false, unique = true)
+	private Member member;
 
 	@Column(name = "token", nullable = false, unique = true)
 	private String token;
@@ -30,8 +33,8 @@ public class RefreshToken {
 	@Column(name = "rt_expired_datetime", nullable = false)
 	private LocalDateTime expiredDateTime;
 
-	public RefreshToken(Long memberId, String token, LocalDateTime expiredDateTime) {
-		this.memberId = memberId;
+	public RefreshToken(Member member, String token, LocalDateTime expiredDateTime) {
+		this.member = member;
 		this.token = token;
 		this.expiredDateTime = expiredDateTime;
 	}

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/RefreshToken.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/RefreshToken.java
@@ -1,5 +1,7 @@
 package com.tteokguk.tteokguk.member.domain;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -25,13 +27,19 @@ public class RefreshToken {
 	@Column(name = "token", nullable = false, unique = true)
 	private String token;
 
+	@Column(name = "rt_expired_datetime", nullable = false)
+	private LocalDateTime expiredDateTime;
+
+
 	@Builder
-	public RefreshToken(Long memberId, String token) {
+	public RefreshToken(Long memberId, String token, LocalDateTime expiredDateTime) {
 		this.memberId = memberId;
 		this.token = token;
+		this.expiredDateTime = expiredDateTime;
 	}
 
-	public void update(String token) {
+	public void update(String token, LocalDateTime expiredDateTime) {
 		this.token = token;
+		this.expiredDateTime = expiredDateTime;
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/RefreshToken.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/RefreshToken.java
@@ -30,8 +30,6 @@ public class RefreshToken {
 	@Column(name = "rt_expired_datetime", nullable = false)
 	private LocalDateTime expiredDateTime;
 
-
-	@Builder
 	public RefreshToken(Long memberId, String token, LocalDateTime expiredDateTime) {
 		this.memberId = memberId;
 		this.token = token;

--- a/src/main/java/com/tteokguk/tteokguk/member/exception/AuthError.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/exception/AuthError.java
@@ -17,8 +17,8 @@ public enum AuthError implements ErrorCode {
 	INVALID_JWT_TOKEN("토큰이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED, "A_006"),
 	EXPIRED_JWT_TOKEN("토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED, "A_007"),
 	UNSUPPORTED_JWT_TOKEN("지원되지 않는 토큰입니다.", HttpStatus.UNAUTHORIZED, "A_008"),
-	EMPTY_VALUE_IN_COOKIE("쿠키에 데이터가 존재하지 않습니다.", HttpStatus.UNAUTHORIZED, "A_009")
-	;
+	EMPTY_VALUE_IN_COOKIE("쿠키에 데이터가 존재하지 않습니다.", HttpStatus.UNAUTHORIZED, "A_009"),
+	UNUSABLE_TOKEN("사용할 수 없는 토큰입니다. 다시 로그인해주세요.", HttpStatus.BAD_REQUEST, "A_010");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/tteokguk/tteokguk/member/infra/persistence/RefreshTokenRepository.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/infra/persistence/RefreshTokenRepository.java
@@ -4,9 +4,10 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.tteokguk.tteokguk.member.domain.Member;
 import com.tteokguk.tteokguk.member.domain.RefreshToken;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-	Optional<RefreshToken> findByMemberId(Long memberId);
+	Optional<RefreshToken> findByMember(Member member);
 	Optional<RefreshToken> findByToken(String token);
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/infra/persistence/RefreshTokenRepository.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/infra/persistence/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.tteokguk.tteokguk.member.infra.persistence;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.tteokguk.tteokguk.member.domain.RefreshToken;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+	Optional<RefreshToken> findByMemberId(Long memberId);
+	Optional<RefreshToken> findByToken(String token);
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/AuthController.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/AuthController.java
@@ -12,8 +12,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.tteokguk.tteokguk.member.application.AuthService;
+import com.tteokguk.tteokguk.member.application.RefreshTokenService;
 import com.tteokguk.tteokguk.member.application.dto.response.AppJoinResponse;
 import com.tteokguk.tteokguk.member.presentation.dto.WebExistedResourceResponse;
+import com.tteokguk.tteokguk.member.presentation.dto.WebIssuedTokensRequest;
+import com.tteokguk.tteokguk.member.presentation.dto.WebIssuedTokensResponse;
 import com.tteokguk.tteokguk.member.presentation.dto.WebJoinRequest;
 import com.tteokguk.tteokguk.member.presentation.dto.WebJoinResponse;
 
@@ -26,24 +29,32 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class AuthController {
 
-	private final AuthService memberService;
+	private final AuthService authService;
+	private final RefreshTokenService refreshTokenService;
 
 	@PostMapping("/join")
 	public ResponseEntity<WebJoinResponse> join(@RequestBody @Validated WebJoinRequest request) {
-		AppJoinResponse appResponse = memberService.join(request.convert());
+		AppJoinResponse appResponse = authService.join(request.convert());
 		return ResponseEntity.created(URI.create("/api/v1/members/" + appResponse.id()))
 			.body(WebJoinResponse.of(appResponse));
 	}
 
 	@GetMapping("/check-email/{email}")
 	public ResponseEntity<WebExistedResourceResponse> checkEmail(@PathVariable String email) {
-		boolean isExist = memberService.existsByEmail(email);
+		boolean isExist = authService.existsByEmail(email);
 		return ResponseEntity.ok(new WebExistedResourceResponse(isExist));
 	}
 
 	@GetMapping("/check-nickname/{nickname}")
 	public ResponseEntity<WebExistedResourceResponse> checkNickname(@PathVariable String nickname) {
-		boolean isExist = memberService.existsByNickname(nickname);
+		boolean isExist = authService.existsByNickname(nickname);
 		return ResponseEntity.ok(new WebExistedResourceResponse(isExist));
+	}
+
+	@PostMapping("/token")
+	public ResponseEntity<WebIssuedTokensResponse> reIssueTokens(@RequestBody WebIssuedTokensRequest request) {
+		return ResponseEntity.ok(
+			WebIssuedTokensResponse.of(refreshTokenService.issueTokens(request.refreshToken()))
+		);
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebIssuedTokensRequest.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebIssuedTokensRequest.java
@@ -1,0 +1,6 @@
+package com.tteokguk.tteokguk.member.presentation.dto;
+
+public record WebIssuedTokensRequest(
+	String refreshToken
+) {
+}

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebIssuedTokensResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebIssuedTokensResponse.java
@@ -1,0 +1,13 @@
+package com.tteokguk.tteokguk.member.presentation.dto;
+
+import com.tteokguk.tteokguk.member.application.dto.response.AppIssuedTokensResponse;
+
+public record WebIssuedTokensResponse(
+	Long id,
+	String accessToken,
+	String refreshToken
+) {
+	public static WebIssuedTokensResponse of(AppIssuedTokensResponse response) {
+		return new WebIssuedTokensResponse(response.id(), response.accessToken(), response.refreshToken());
+	}
+}


### PR DESCRIPTION
## Issue ticket link and number
- #44 

## Describe changes
- JwtFactory를 직접 사용하는 것이 아닌, JwtService를 통해 접근 토큰과 갱신 토큰을 생성하는 방식으로 한 단계 추상화하였습니다.
- 갱신 토큰을 활용하여 접근 토큰과 갱신 토큰을 재발급하는 API를 생성하였습니다.
- 보안성을 높이기 위해 접근 토큰 뿐만 아니라 갱신 토큰도 재발급합니다.

## Notification for Reviewer
@h-beeen 

close #44