### PR TITLE
[FEATURE] #53 유저 탈퇴 API

### DIFF
--- a/src/main/java/com/tteokguk/tteokguk/member/application/UserInfoService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/UserInfoService.java
@@ -1,5 +1,10 @@
 package com.tteokguk.tteokguk.member.application;
 
+import static com.tteokguk.tteokguk.member.exception.MemberError.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.tteokguk.tteokguk.global.exception.BusinessException;
 import com.tteokguk.tteokguk.member.application.dto.request.AppInitRequest;
 import com.tteokguk.tteokguk.member.application.dto.response.AppInitResponse;
@@ -9,11 +14,8 @@ import com.tteokguk.tteokguk.member.application.dto.response.assembler.UserInfoR
 import com.tteokguk.tteokguk.member.domain.Member;
 import com.tteokguk.tteokguk.member.exception.MemberError;
 import com.tteokguk.tteokguk.member.infra.persistence.MemberRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import static com.tteokguk.tteokguk.member.exception.MemberError.MEMBER_NOT_FOUND;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional
@@ -51,5 +53,12 @@ public class UserInfoService {
         member.initialize(request.nickname(), request.acceptsMarketing());
 
         return AppInitResponse.of(member);
+    }
+
+    public void delete(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> BusinessException.of(MEMBER_NOT_FOUND));
+
+        member.delete();
     }
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/Member.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/Member.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import static com.tteokguk.tteokguk.item.exception.ItemError.INSUFFICIENT_INGREDIENTS;
 import static com.tteokguk.tteokguk.item.exception.ItemError.UNKNOWN_INGREDIENT;
@@ -20,11 +21,15 @@ import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Where;
+
 @Entity
 @Getter
 @Table(name = "t_member")
 @NoArgsConstructor(access = PROTECTED)
 @Inheritance
+@Where(clause = "deleted = false")
 public class Member extends BaseEntity {
 
     @Id
@@ -57,6 +62,10 @@ public class Member extends BaseEntity {
 
     @Column(name = "accepts_marketing")
     private Boolean acceptsMarketing;
+
+    @Column(name = "deleted")
+    @ColumnDefault("false")
+    private boolean deleted;
 
     protected Member(
             Ingredient primaryIngredient,
@@ -154,5 +163,10 @@ public class Member extends BaseEntity {
         this.nickname = nickname;
         this.acceptsMarketing = acceptsMarketing;
         this.role = RoleType.ROLE_USER;
+    }
+
+    public void delete() {
+        this.nickname = this.nickname + "::deleted::" + UUID.randomUUID().toString().substring(0, 8);
+        this.deleted = true;
     }
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/OAuthMember.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/OAuthMember.java
@@ -4,6 +4,7 @@ import static lombok.AccessLevel.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.tteokguk.tteokguk.item.domain.Item;
 import com.tteokguk.tteokguk.tteokguk.constants.Ingredient;
@@ -56,5 +57,11 @@ public class OAuthMember extends Member {
 
 		member.initializeItem(primaryIngredient);
 		return member;
+	}
+
+	@Override
+	public void delete() {
+		super.delete();
+		this.resourceId = this.resourceId + "::deleted::" + UUID.randomUUID().toString().substring(0, 8);
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/SimpleMember.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/SimpleMember.java
@@ -1,16 +1,18 @@
 package com.tteokguk.tteokguk.member.domain;
 
+import static lombok.AccessLevel.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
 import com.tteokguk.tteokguk.item.domain.Item;
 import com.tteokguk.tteokguk.tteokguk.constants.Ingredient;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
@@ -18,7 +20,6 @@ import static lombok.AccessLevel.PROTECTED;
 public class SimpleMember extends Member {
 
     @Column(name = "email",
-            updatable = false,
             unique = true)
     private String email;
 
@@ -54,4 +55,10 @@ public class SimpleMember extends Member {
         member.initializeItem(primaryIngredient);
         return member;
     }
+
+	@Override
+	public void delete() {
+		super.delete();
+		this.email = this.email + "::deleted::" + UUID.randomUUID().toString().substring(0, 8);
+	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/UserInfoController.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/UserInfoController.java
@@ -47,4 +47,10 @@ public class UserInfoController {
         AppInitResponse response = userInfoService.initialize(id, request.convert());
         return ResponseEntity.ok(WebInitResponse.of(response));
     }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> delete(@AuthId Long id) {
+        userInfoService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
 }


### PR DESCRIPTION
## Issue ticket link and number
- #53 

## Describe changes
- 유저 탈퇴 API를 생성하였습니다.
- 유저가 탈퇴할 경우, `현재닉네임::deleted::UUID(앞 8자)`의 형태로 닉네임을 변경합니다.
- 이메일 로그인 유저일 경우, 이메일을 `현재이메일::deleted:UUID(앞 8자)`의 형태로 변경합니다.
- 소셜 로그인 유저일 경우, 소셜 벤더 식별자를 `식별자::deleted:UUID(앞 8자)`의 형태로 변경합니다.
- 탈퇴한 유저의 경우 @Where 애노테이션을 통해 memberRepository를 통해 조회하는 모든 곳에서 유저를 조회할 수 없도록 했습니다.