### PR TITLE
bug: 응원한 떡국 조회 API

### DIFF
--- a/src/main/java/com/tteokguk/tteokguk/support/application/SupportService.java
+++ b/src/main/java/com/tteokguk/tteokguk/support/application/SupportService.java
@@ -13,6 +13,7 @@ import com.tteokguk.tteokguk.support.application.dto.response.assembler.SupportR
 import com.tteokguk.tteokguk.support.domain.Support;
 import com.tteokguk.tteokguk.support.infra.persistence.SupportQueryRepository;
 import com.tteokguk.tteokguk.support.infra.persistence.SupportRepository;
+import com.tteokguk.tteokguk.tteokguk.application.dto.response.assembler.TteokgukResponseAssembler;
 import com.tteokguk.tteokguk.tteokguk.domain.Tteokguk;
 import com.tteokguk.tteokguk.tteokguk.infra.persistence.TteokgukRepository;
 import lombok.RequiredArgsConstructor;
@@ -82,7 +83,8 @@ public class SupportService {
                 request.size(),
                 Sort.by(DESC, "support_id"));
 
-        List<SupportTteokgukResponse> responses = supportQueryRepository.getSupportTteokgukResponse(id, pageable);
+        List<Support> supports = supportRepository.findSupportTteokguks(id);
+        List<SupportTteokgukResponse> responses = TteokgukResponseAssembler.toSupportTteokgukResponses(supports);
         return new PageImpl<>(responses, pageable, responses.size());
     }
 }

--- a/src/main/java/com/tteokguk/tteokguk/support/application/SupportService.java
+++ b/src/main/java/com/tteokguk/tteokguk/support/application/SupportService.java
@@ -8,6 +8,7 @@ import com.tteokguk.tteokguk.support.application.dto.SupportRequest;
 import com.tteokguk.tteokguk.support.application.dto.request.SupportPageableRequest;
 import com.tteokguk.tteokguk.support.application.dto.response.ReceivedIngredientResponse;
 import com.tteokguk.tteokguk.support.application.dto.response.SupportResponse;
+import com.tteokguk.tteokguk.support.application.dto.response.SupportTteokgukResponse;
 import com.tteokguk.tteokguk.support.application.dto.response.assembler.SupportResponseAssembler;
 import com.tteokguk.tteokguk.support.domain.Support;
 import com.tteokguk.tteokguk.support.infra.persistence.SupportQueryRepository;
@@ -69,6 +70,19 @@ public class SupportService {
                 Sort.by(DESC, "support_id"));
 
         List<ReceivedIngredientResponse> responses = supportQueryRepository.getReceivedIngredientResponse(id, pageable);
+        return new PageImpl<>(responses, pageable, responses.size());
+    }
+
+    public Page<SupportTteokgukResponse> getSupportTteokgukResponse(
+            Long id,
+            SupportPageableRequest request
+    ) {
+        PageRequest pageable = PageRequest.of(
+                request.page() - 1,
+                request.size(),
+                Sort.by(DESC, "support_id"));
+
+        List<SupportTteokgukResponse> responses = supportQueryRepository.getSupportTteokgukResponse(id, pageable);
         return new PageImpl<>(responses, pageable, responses.size());
     }
 }

--- a/src/main/java/com/tteokguk/tteokguk/support/application/dto/request/SupportPageableRequest.java
+++ b/src/main/java/com/tteokguk/tteokguk/support/application/dto/request/SupportPageableRequest.java
@@ -1,6 +1,5 @@
 package com.tteokguk.tteokguk.support.application.dto.request;
 
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -12,10 +11,6 @@ public record SupportPageableRequest(
 
         @Min(value = 1, message = "페이지 수는 최소 1개 이상입니다.")
         @NotNull(message = "페이지 수는 필수입니다.")
-        Integer size,
-        
-        @Min(value = 1, message = "페이지 번호 목록 갯수는 최소 1개 이상 입니다.")
-        @Max(value = 10, message = "페이지 번호 목록 갯수는 최대 10개 입니다.")
-        Integer count
+        Integer size
 ) {
 }

--- a/src/main/java/com/tteokguk/tteokguk/support/application/dto/response/SupportTteokgukResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/support/application/dto/response/SupportTteokgukResponse.java
@@ -1,13 +1,11 @@
 package com.tteokguk.tteokguk.support.application.dto.response;
 
-import com.tteokguk.tteokguk.tteokguk.constants.Ingredient;
-
 import java.util.List;
 
 public record SupportTteokgukResponse(
         Long tteokgukId,
         String receiverNickname,
         Boolean completion,
-        List<Ingredient> ingredients
+        List<?> ingredients
 ) {
 }

--- a/src/main/java/com/tteokguk/tteokguk/support/application/dto/response/SupportTteokgukResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/support/application/dto/response/SupportTteokgukResponse.java
@@ -1,0 +1,13 @@
+package com.tteokguk.tteokguk.support.application.dto.response;
+
+import com.tteokguk.tteokguk.tteokguk.constants.Ingredient;
+
+import java.util.List;
+
+public record SupportTteokgukResponse(
+        Long tteokgukId,
+        String receiverNickname,
+        Boolean completion,
+        List<Ingredient> ingredients
+) {
+}

--- a/src/main/java/com/tteokguk/tteokguk/support/infra/persistence/SupportQueryRepository.java
+++ b/src/main/java/com/tteokguk/tteokguk/support/infra/persistence/SupportQueryRepository.java
@@ -4,7 +4,6 @@ import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.tteokguk.tteokguk.support.application.dto.response.ReceivedIngredientResponse;
-import com.tteokguk.tteokguk.support.application.dto.response.SupportTteokgukResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -35,19 +34,6 @@ public class SupportQueryRepository {
                 .fetch();
     }
 
-    public List<SupportTteokgukResponse> getSupportTteokgukResponse(
-            Long id,
-            Pageable pageable
-    ) {
-        List<Long> supportIds = getSenderSupportIds(id, pageable);
-
-        return query
-                .select(getSupportTteokgukResponseConstructorExpression())
-                .from(support)
-                .where(support.id.in(supportIds))
-                .orderBy(support.id.desc())
-                .fetch();
-    }
 
     public List<Long> getReceiverSupportIds(
             Long id,
@@ -85,16 +71,6 @@ public class SupportQueryRepository {
                 support.supportIngredient,
                 support.message,
                 support.access
-        );
-    }
-
-    private ConstructorExpression<SupportTteokgukResponse> getSupportTteokgukResponseConstructorExpression() {
-        return Projections.constructor(
-                SupportTteokgukResponse.class,
-                support.supportedTteokguk.id,
-                support.receiver.nickname,
-                support.supportedTteokguk.completion,
-                Projections.list(support.supportedTteokguk.usedIngredients)
         );
     }
 }

--- a/src/main/java/com/tteokguk/tteokguk/support/infra/persistence/SupportRepository.java
+++ b/src/main/java/com/tteokguk/tteokguk/support/infra/persistence/SupportRepository.java
@@ -2,8 +2,15 @@ package com.tteokguk.tteokguk.support.infra.persistence;
 
 import com.tteokguk.tteokguk.support.domain.Support;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Transactional
 public interface SupportRepository extends JpaRepository<Support, Long> {
+
+    @Query("SELECT s FROM Support s GROUP BY s.supportedTteokguk.id HAVING s.sender.id = :id")
+    List<Support> findSupportTteokguks(@Param("id") Long id);
 }

--- a/src/main/java/com/tteokguk/tteokguk/support/presentation/SupportController.java
+++ b/src/main/java/com/tteokguk/tteokguk/support/presentation/SupportController.java
@@ -7,6 +7,7 @@ import com.tteokguk.tteokguk.support.application.dto.SupportRequest;
 import com.tteokguk.tteokguk.support.application.dto.request.SupportPageableRequest;
 import com.tteokguk.tteokguk.support.application.dto.response.ReceivedIngredientResponse;
 import com.tteokguk.tteokguk.support.application.dto.response.SupportResponse;
+import com.tteokguk.tteokguk.support.application.dto.response.SupportTteokgukResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -37,6 +38,16 @@ public class SupportController {
     ) {
         Page<ReceivedIngredientResponse> pagedResponse = supportService.getReceivedIngredientResponse(id, request);
         ApiPageResponse<ReceivedIngredientResponse> pagedApiResponse = ApiPageResponse.of(pagedResponse);
+        return ResponseEntity.ok(pagedApiResponse);
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiPageResponse<SupportTteokgukResponse>> getSupportResponse(
+            @AuthId Long id,
+            @Valid SupportPageableRequest request
+    ) {
+        Page<SupportTteokgukResponse> pageResponse = supportService.getSupportTteokgukResponse(id, request);
+        ApiPageResponse<SupportTteokgukResponse> pagedApiResponse = ApiPageResponse.of(pageResponse);
         return ResponseEntity.ok(pagedApiResponse);
     }
 }

--- a/src/main/java/com/tteokguk/tteokguk/tteokguk/application/dto/response/assembler/TteokgukResponseAssembler.java
+++ b/src/main/java/com/tteokguk/tteokguk/tteokguk/application/dto/response/assembler/TteokgukResponseAssembler.java
@@ -1,8 +1,12 @@
 package com.tteokguk.tteokguk.tteokguk.application.dto.response.assembler;
 
+import com.tteokguk.tteokguk.support.application.dto.response.SupportTteokgukResponse;
+import com.tteokguk.tteokguk.support.domain.Support;
 import com.tteokguk.tteokguk.tteokguk.application.dto.response.TteokgukResponse;
 import com.tteokguk.tteokguk.tteokguk.domain.Tteokguk;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 import static lombok.AccessLevel.PRIVATE;
 
@@ -18,5 +22,16 @@ public class TteokgukResponseAssembler {
                 .access(tteokguk.isAccess())
                 .completion(tteokguk.isCompletion())
                 .build();
+    }
+
+    public static List<SupportTteokgukResponse> toSupportTteokgukResponses(List<Support> supports) {
+        return supports.stream()
+                .map(support -> new SupportTteokgukResponse(
+                        support.getSupportedTteokguk().getId(),
+                        support.getReceiver().getNickname(),
+                        support.getSupportedTteokguk().isCompletion(),
+                        support.getSupportedTteokguk().getUsedIngredients()
+                ))
+                .toList();
     }
 }


### PR DESCRIPTION
## Issue ticket link and number
- #8 
- #56 

## Describe changes
- 내가 응원한 떡국 조회 API 입니다. `/api/v1/support?page={pageNum}&size={size}`
- 현재 쿼리 패칭 간 List 조회에 오류가 있습니다.
- [동일 현상 영한님 질문/답변](https://www.inflearn.com/questions/547039/querydsl%EC%97%90%EC%84%9C%EC%9D%98-%EA%B0%92-%ED%83%80%EC%9E%85-%EC%BB%AC%EB%A0%89%EC%85%98)

- Excpected Return Value

```json
{
    "data": [
        {
            "tteokgukId": 1,
            "receiverNickname": "햅",
            "completion": false,
            "ingredients": [
                "RICE_CAKE",
                "TOFU"
            ]
        }
    ]
    "pageInfo": {
        "page": 1,
        "size": 5
    }
}
```

- API Return Value
```json
{
    "data": [
        {
            "tteokgukId": 1,
            "receiverNickname": "햅",
            "completion": false,
            "ingredients": [
                "RICE_CAKE"
            ]
        },
        {
            "tteokgukId": 1,
            "receiverNickname": "햅",
            "completion": false,
            "ingredients": [
                "TOFU"
            ]
        }
    ],
    "pageInfo": {
        "page": 1,
        "size": 5
    }
}
```

- 리스트를 쿼리패칭하는 시도를 처음 해보는데, 어려움을 겪고 있습니다...!
- 현재 `Projections.list(support.supportedTteokguk.usedIngredients)`와 같이 Dto를 패칭하는데,
Projection을 사용하지 않으면 ArgumentMissMatchingException이 발생하고, 위와 같이 프로젝션을 걸게되면
리스트가 분리되어 위 `API Return Value` 와 같은 반환값을 갖게 됩니다.
- 명범님의 지식으로 도움이 필요합니다 :)

## Notification for Reviewer
