### PR TITLE
[FIX] #70 이메일 응답 반환 수정 및 중복 초기화 불가 로직 추가

### DIFF
--- a/src/main/java/com/tteokguk/tteokguk/member/application/UserInfoService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/UserInfoService.java
@@ -12,7 +12,6 @@ import com.tteokguk.tteokguk.member.application.dto.response.MyPageResponse;
 import com.tteokguk.tteokguk.member.application.dto.response.UserInfoResponse;
 import com.tteokguk.tteokguk.member.application.dto.response.assembler.UserInfoResponseAssembler;
 import com.tteokguk.tteokguk.member.domain.Member;
-import com.tteokguk.tteokguk.member.exception.MemberError;
 import com.tteokguk.tteokguk.member.infra.persistence.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -44,11 +43,14 @@ public class UserInfoService {
     }
 
     public AppInitResponse initialize(Long memberId, AppInitRequest request) {
-        if (memberRepository.existsByNickname(request.nickname()))
-            throw new BusinessException(MemberError.DUPLICATE_EMAIL);
-
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> BusinessException.of(MEMBER_NOT_FOUND));
+
+        if (member.isInitialized())
+            throw new BusinessException(ALREADY_INITIALIZED_USER);
+
+        if (memberRepository.existsByNickname(request.nickname()))
+            throw new BusinessException(DUPLICATE_NICKNAME);
 
         member.initialize(request.nickname(), request.acceptsMarketing());
 

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/Member.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/Member.java
@@ -164,6 +164,10 @@ public class Member extends BaseEntity {
         this.role = RoleType.ROLE_USER;
     }
 
+    public boolean isInitialized() {
+        return this.role != RoleType.ROLE_TEMP_USER;
+    }
+
     public void delete() {
         this.nickname = this.nickname + "::deleted::" + UUID.randomUUID().toString().substring(0, 8);
         this.deleted = true;

--- a/src/main/java/com/tteokguk/tteokguk/member/exception/MemberError.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/exception/MemberError.java
@@ -16,6 +16,7 @@ public enum MemberError implements ErrorCode {
 	MEMBER_NOT_FOUND("해당 사용자를 찾을 수 없습니다.", NOT_FOUND, "M_001"),
 	DUPLICATE_EMAIL("이메일이 중복되었습니다.", BAD_REQUEST, "M_002"),
 	DUPLICATE_NICKNAME("닉네임이 중복되었습니다.", BAD_REQUEST, "M_003"),
+	ALREADY_INITIALIZED_USER("이미 초기화된 유저입니다.", BAD_REQUEST, "M_004"),
 	;
 
 	private final String message;


### PR DESCRIPTION
## Issue ticket link and number
- #70 

## Describe changes
- 닉네임 중복 시 이메일 중복이라는 응답을 반환하는 버그를 수정했습니다.
- 초기화 된 유저는 다시 초기화할 수 없도록 로직을 수정했습니다.

close #70 