### PR TITLE
[FEATURE] #80 카카오 로그인, 일반 로그인, 토큰 갱신 시 닉네임, 전용 재료, 유저의 재료 재고를 응답에 추가

### DIFF
--- a/src/main/java/com/tteokguk/tteokguk/global/security/dto/WebLoginResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/security/dto/WebLoginResponse.java
@@ -1,7 +1,15 @@
 package com.tteokguk.tteokguk.global.security.dto;
 
+import java.util.List;
+
+import com.tteokguk.tteokguk.item.application.dto.response.ItemResponse;
+import com.tteokguk.tteokguk.tteokguk.constants.Ingredient;
+
 public record WebLoginResponse(
 	Long id,
+	String nickname,
+	Ingredient primaryIngridient,
+	List<ItemResponse> items,
 	String accessToken,
 	String refreshToken
 ) {

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/AuthController.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/AuthController.java
@@ -5,7 +5,6 @@ import java.net.URI;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,7 +12,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.tteokguk.tteokguk.member.application.AuthService;
 import com.tteokguk.tteokguk.member.application.RefreshTokenService;
+import com.tteokguk.tteokguk.member.application.UserInfoService;
+import com.tteokguk.tteokguk.member.application.dto.response.AppIssuedTokensResponse;
 import com.tteokguk.tteokguk.member.application.dto.response.AppJoinResponse;
+import com.tteokguk.tteokguk.member.application.dto.response.MyPageResponse;
 import com.tteokguk.tteokguk.member.presentation.dto.WebCheckEmailRequest;
 import com.tteokguk.tteokguk.member.presentation.dto.WebCheckNicknameRequest;
 import com.tteokguk.tteokguk.member.presentation.dto.WebExistedResourceResponse;
@@ -32,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AuthController {
 
 	private final AuthService authService;
+	private final UserInfoService userInfoService;
 	private final RefreshTokenService refreshTokenService;
 
 	@PostMapping("/join")
@@ -55,8 +58,10 @@ public class AuthController {
 
 	@PostMapping("/token")
 	public ResponseEntity<WebIssuedTokensResponse> reIssueTokens(@RequestBody WebIssuedTokensRequest request) {
+		AppIssuedTokensResponse issuedTokensResponse = refreshTokenService.issueTokens(request.refreshToken());
+		MyPageResponse myInfoResponse = userInfoService.getMyPageInfo(issuedTokensResponse.id());
 		return ResponseEntity.ok(
-			WebIssuedTokensResponse.of(refreshTokenService.issueTokens(request.refreshToken()))
+			WebIssuedTokensResponse.of(issuedTokensResponse, myInfoResponse)
 		);
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/OAuthController.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/OAuthController.java
@@ -14,7 +14,9 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.tteokguk.tteokguk.global.exception.BusinessException;
 import com.tteokguk.tteokguk.member.application.OAuthService;
+import com.tteokguk.tteokguk.member.application.UserInfoService;
 import com.tteokguk.tteokguk.member.application.dto.response.AppOAuthLoginResponse;
+import com.tteokguk.tteokguk.member.application.dto.response.MyPageResponse;
 import com.tteokguk.tteokguk.member.domain.ProviderType;
 import com.tteokguk.tteokguk.member.exception.AuthError;
 import com.tteokguk.tteokguk.member.presentation.dto.WebOAuthLoginRequest;
@@ -31,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 public class OAuthController {
 
 	private final OAuthService oAuthService;
+	private final UserInfoService userInfoService;
 
 	@GetMapping("/{provider}/login")
 	public String oAuthLogin(@PathVariable String provider, @RequestParam String code, HttpServletRequest request) {
@@ -59,6 +62,7 @@ public class OAuthController {
 		AppOAuthLoginResponse response = oAuthService.getByAccessToken(
 			ProviderType.valueOf(provider.toUpperCase()), request.accessToken()
 		);
-		return ResponseEntity.ok(WebOAuthLoginResponse.of(response));
+		MyPageResponse myPageInfo = userInfoService.getMyPageInfo(response.id());
+		return ResponseEntity.ok(WebOAuthLoginResponse.of(response, myPageInfo));
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebIssuedTokensResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebIssuedTokensResponse.java
@@ -1,13 +1,28 @@
 package com.tteokguk.tteokguk.member.presentation.dto;
 
+import java.util.List;
+
+import com.tteokguk.tteokguk.item.application.dto.response.ItemResponse;
 import com.tteokguk.tteokguk.member.application.dto.response.AppIssuedTokensResponse;
+import com.tteokguk.tteokguk.member.application.dto.response.MyPageResponse;
+import com.tteokguk.tteokguk.tteokguk.constants.Ingredient;
 
 public record WebIssuedTokensResponse(
 	Long id,
+	String nickname,
+	Ingredient primaryIngredient,
+	List<ItemResponse> items,
 	String accessToken,
 	String refreshToken
 ) {
-	public static WebIssuedTokensResponse of(AppIssuedTokensResponse response) {
-		return new WebIssuedTokensResponse(response.id(), response.accessToken(), response.refreshToken());
+	public static WebIssuedTokensResponse of(AppIssuedTokensResponse response, MyPageResponse myInfo) {
+		return new WebIssuedTokensResponse(
+			response.id(),
+			myInfo.nickname(),
+			myInfo.primaryIngredient(),
+			myInfo.items(),
+			response.accessToken(),
+			response.refreshToken()
+		);
 	}
 }

--- a/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebOAuthLoginResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/presentation/dto/WebOAuthLoginResponse.java
@@ -1,16 +1,27 @@
 package com.tteokguk.tteokguk.member.presentation.dto;
 
+import java.util.List;
+
+import com.tteokguk.tteokguk.item.application.dto.response.ItemResponse;
 import com.tteokguk.tteokguk.member.application.dto.response.AppOAuthLoginResponse;
+import com.tteokguk.tteokguk.member.application.dto.response.MyPageResponse;
+import com.tteokguk.tteokguk.tteokguk.constants.Ingredient;
 
 public record WebOAuthLoginResponse(
 	Long id,
+	String nickname,
+	Ingredient primaryIngredient,
+	List<ItemResponse> items,
 	String accessToken,
 	String refreshToken,
 	boolean isInitialized
 ) {
-	public static WebOAuthLoginResponse of(AppOAuthLoginResponse response) {
+	public static WebOAuthLoginResponse of(AppOAuthLoginResponse response, MyPageResponse myInfo) {
 		return new WebOAuthLoginResponse(
 			response.id(),
+			myInfo.nickname(),
+			myInfo.primaryIngredient(),
+			myInfo.items(),
 			response.accessToken(),
 			response.refreshToken(),
 			response.isInitialized()


### PR DESCRIPTION
## Issue ticket link and number
- #80 

## Describe changes
- 카카오 로그인, 일반 로그인, 토큰 갱신 시 닉네임, 전용 재료, 유저의 재료 재고를 응답에 추가