### PR TITLE
[FIX] #91 삭제된 유저의 검증을 도메인 로직에서 제외하고, 서비스 레이어에서 하도록 변경

### DIFF
--- a/src/main/java/com/tteokguk/tteokguk/member/application/UserInfoService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/UserInfoService.java
@@ -96,7 +96,7 @@ public class UserInfoService {
 
         Pageable pageable = PageRequest.of(page - 1, size);
 
-        Page<Member> members = memberRepository.findByNicknameStartingWith(nickname, pageable);
+        Page<Member> members = memberRepository.findByNicknameStartingWithAndDeleted(nickname, pageable, false);
 
         List<MemberResponse> content =
             members.map(UserInfoResponseAssembler::transferToMemberResponse).getContent();
@@ -107,7 +107,7 @@ public class UserInfoService {
         if (!StringUtils.hasText(nickname))
             return Collections.emptyList();
 
-        List<Member> members = memberRepository.findAllByNicknameStartingWith(nickname);
+        List<Member> members = memberRepository.findAllByNicknameStartingWithAndDeleted(nickname, false);
 
         return members.stream()
             .map(UserInfoResponseAssembler::transferToMemberResponse)

--- a/src/main/java/com/tteokguk/tteokguk/member/application/UserInfoService.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/application/UserInfoService.java
@@ -41,12 +41,18 @@ public class UserInfoService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> BusinessException.of(MEMBER_NOT_FOUND));
 
+        if (member.isDeleted())
+            throw new BusinessException(DELETED_MEMBER);
+
         return UserInfoResponseAssembler.transferToMyPageResponse(member);
     }
 
     public UserInfoResponse getUserInfo(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> BusinessException.of(MEMBER_NOT_FOUND));
+
+        if (member.isDeleted())
+            throw new BusinessException(DELETED_MEMBER);
 
         return UserInfoResponseAssembler.transferToUserInfoResponse(member);
     }
@@ -117,6 +123,9 @@ public class UserInfoService {
     public AppMyIngredientResponse getMyIngredients(Long id) {
         Member member = memberRepository.findById(id)
             .orElseThrow(() -> BusinessException.of(MEMBER_NOT_FOUND));
+
+        if (member.isDeleted())
+            throw new BusinessException(DELETED_MEMBER);
 
         return AppMyIngredientResponse.of(member);
     }

--- a/src/main/java/com/tteokguk/tteokguk/member/domain/Member.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/domain/Member.java
@@ -28,7 +28,6 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "t_member")
 @NoArgsConstructor(access = PROTECTED)
 @Inheritance
-@Where(clause = "deleted = false")
 public class Member extends BaseEntity {
 
     @Id

--- a/src/main/java/com/tteokguk/tteokguk/member/exception/MemberError.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/exception/MemberError.java
@@ -17,6 +17,7 @@ public enum MemberError implements ErrorCode {
 	DUPLICATE_EMAIL("이메일이 중복되었습니다.", BAD_REQUEST, "M_002"),
 	DUPLICATE_NICKNAME("닉네임이 중복되었습니다.", BAD_REQUEST, "M_003"),
 	ALREADY_INITIALIZED_USER("이미 초기화된 유저입니다.", BAD_REQUEST, "M_004"),
+	DELETED_MEMBER("탈퇴한 유저입니다.", NOT_FOUND, "M_005")
 	;
 
 	private final String message;

--- a/src/main/java/com/tteokguk/tteokguk/member/infra/persistence/MemberRepository.java
+++ b/src/main/java/com/tteokguk/tteokguk/member/infra/persistence/MemberRepository.java
@@ -21,7 +21,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByNickname(String nickname);
 
-    Page<Member> findByNicknameStartingWith(String nickname, Pageable pageable);
+    Page<Member> findByNicknameStartingWithAndDeleted(String nickname, Pageable pageable, boolean deleted);
 
-    List<Member> findAllByNicknameStartingWith(String nickname);
+    List<Member> findAllByNicknameStartingWithAndDeleted(String nickname, boolean deleted);
 }


### PR DESCRIPTION
## Issue ticket link and number
- #91 

## Describe changes
- 도메인 로직 내 `@Where` 애노테이션을 삭제했습니다.
- MemberError에 탈퇴 관련 Enum을 추가하였습니다.
- 유저 검색 API에서 사용하는 리포지토리 메서드를 변경하였습니다.
- UserInfoService 내에서 탈퇴한 멤버에 접근 시, 탈퇴 예외 응답을 반환하도록 수정했습니다.

## Notification for Reviewer
@h-beeen 