### PR TITLE
[FIX] {id}에 숫자를 제외한 문자열도 포함하는 버그 수정

### DIFF
--- a/src/main/java/com/tteokguk/tteokguk/global/security/matcher/CustomRequestMatcher.java
+++ b/src/main/java/com/tteokguk/tteokguk/global/security/matcher/CustomRequestMatcher.java
@@ -36,7 +36,7 @@ public class CustomRequestMatcher {
         return new OrRequestMatcher(
             new AntPathRequestMatcher("/api/v1/user", HttpMethod.GET.toString()),
             new AntPathRequestMatcher("/api/v1/user/all", HttpMethod.GET.toString()),
-            new AntPathRequestMatcher("/api/v1/user/{id}", HttpMethod.GET.toString()),
+            new AntPathRequestMatcher("/api/v1/user/{id:\\d+}", HttpMethod.GET.toString()),
             new AntPathRequestMatcher("/api/v1/user/random", HttpMethod.GET.toString())
         );
     }


### PR DESCRIPTION
## Describe changes
- PathMatcher에서 userEndpoint 중 {id}에 숫자를 제외한 문자열도 포함하는 버그 수정