### PR TITLE
[FIX] 받은 떡국 재료 조회 API 수정

### DIFF
--- a/src/main/java/com/tteokguk/tteokguk/support/application/dto/response/ReceivedIngredientResponse.java
+++ b/src/main/java/com/tteokguk/tteokguk/support/application/dto/response/ReceivedIngredientResponse.java
@@ -8,6 +8,7 @@ public record ReceivedIngredientResponse(
         String nickname,
         Ingredient ingredient,
         String message,
-        boolean access
+        boolean access,
+		Long supportedTteokgukId
 ) {
 }

--- a/src/main/java/com/tteokguk/tteokguk/support/infra/persistence/SupportQueryRepository.java
+++ b/src/main/java/com/tteokguk/tteokguk/support/infra/persistence/SupportQueryRepository.java
@@ -29,7 +29,7 @@ public class SupportQueryRepository {
         return query
                 .select(getReceivedIngredientResponseConstructorExpression())
                 .from(support)
-                .where(support.id.in(supportIds))
+                .where(support.id.in(supportIds).and(support.supportedTteokguk.deleted.eq(false)))
                 .orderBy(support.id.desc())
                 .fetch();
     }

--- a/src/main/java/com/tteokguk/tteokguk/support/infra/persistence/SupportQueryRepository.java
+++ b/src/main/java/com/tteokguk/tteokguk/support/infra/persistence/SupportQueryRepository.java
@@ -70,7 +70,8 @@ public class SupportQueryRepository {
                 support.sender.nickname,
                 support.supportIngredient,
                 support.message,
-                support.access
+                support.access,
+                support.supportedTteokguk.id
         );
     }
 }


### PR DESCRIPTION
## Describe changes
- 받은 떡국 재료 조회 API에 응원 받은 떡국의 ID를 응답에 추가
- 삭제된 떡국인 경우에 응답에서 제외하도록 변경